### PR TITLE
Handicap Calculator

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -244,7 +244,10 @@ dependencies {
     testImplementation dependencies.kotlinTestJunit
 
     androidTestImplementation dependencies.truth
-    androidTestImplementation dependencies.androidxTestCore
+ //   androidTestImplementation dependencies.androidxTestCore
+//    androidTestImplementation dependencies.androidxTestMonitor
+    androidTestImplementation 'androidx.test:core:1.1.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
     androidTestImplementation dependencies.runner
     androidTestImplementation dependencies.rules
     androidTestUtil dependencies.androidTestOrchestrator

--- a/app/src/main/java/de/dreier/mytargets/features/scoreboard/layout/DefaultScoreboardLayout.kt
+++ b/app/src/main/java/de/dreier/mytargets/features/scoreboard/layout/DefaultScoreboardLayout.kt
@@ -234,21 +234,28 @@ class DefaultScoreboardLayout(
         for (topScore in topScores) {
             row.addBoldCell(topScore.first!!)
         }
-        row.addBoldCell(context.getString(R.string.hits))
-        row.addBoldCell(context.getString(R.string.avg_symbol))
-        row.addBoldCell(context.getString(R.string.handicap_symbol))
         row = table.startRow()
 
         for (topScore in topScores) {
             row.addCell(topScore.second!!)
         }
-        row.addCell("$hits/$total")
-        row.addCell(getAverageScore(scoreDistribution))
 
-        var handicap = MultiRoundHandicapCalculator(rounds).getHandicap()
-        row.addCell(handicap.toString())
+        val summaryTable = Table(false)
+        var summaryRow: Table.Row = summaryTable.startRow()
+        summaryRow.addBoldCell(context.getString(R.string.hits))
+        summaryRow.addCell("$hits/$total")
+        summaryRow.addBoldCell(context.getString(R.string.avg_symbol))
+        summaryRow.addCell(getAverageScore(scoreDistribution))
+        summaryRow.addBoldCell(context.getString(R.string.handicap_symbol))
+        summaryRow.addCell(MultiRoundHandicapCalculator(rounds).getHandicap())
 
-        return table
+        val enclosingTable = Table(false)
+        var scoresRow = enclosingTable.startRow()
+        scoresRow.addCell(table)
+        var summaryLine = enclosingTable.startRow()
+        summaryLine.addCell(summaryTable)
+
+        return enclosingTable
     }
 
     private fun getAverageScore(scoreDistribution: List<Map.Entry<SelectableZone, Int>>): String {

--- a/app/src/main/java/de/dreier/mytargets/features/scoreboard/layout/DefaultScoreboardLayout.kt
+++ b/app/src/main/java/de/dreier/mytargets/features/scoreboard/layout/DefaultScoreboardLayout.kt
@@ -26,6 +26,7 @@ import de.dreier.mytargets.features.scoreboard.ScoreboardConfiguration
 import de.dreier.mytargets.features.scoreboard.builder.model.Table
 import de.dreier.mytargets.features.scoreboard.builder.model.TextCell
 import de.dreier.mytargets.features.settings.SettingsManager
+import de.dreier.mytargets.shared.models.MultiRoundHandicapCalculator
 import de.dreier.mytargets.shared.models.SelectableZone
 import de.dreier.mytargets.shared.models.Target
 import de.dreier.mytargets.shared.models.db.Round
@@ -228,8 +229,6 @@ class DefaultScoreboardLayout(
 
         val topScores = ScoreUtils.getTopScoreDistribution(scoreDistribution)
 
-//        val handicap = "Handicap: 34"
-
         val table = Table(false)
         var row: Table.Row = table.startRow()
         for (topScore in topScores) {
@@ -246,7 +245,8 @@ class DefaultScoreboardLayout(
         row.addCell("$hits/$total")
         row.addCell(getAverageScore(scoreDistribution))
 
-        row.addCell("42")
+        var handicap = MultiRoundHandicapCalculator(rounds).getHandicap()
+        row.addCell(handicap.toString())
 
         return table
     }

--- a/app/src/main/java/de/dreier/mytargets/features/scoreboard/layout/DefaultScoreboardLayout.kt
+++ b/app/src/main/java/de/dreier/mytargets/features/scoreboard/layout/DefaultScoreboardLayout.kt
@@ -228,13 +228,16 @@ class DefaultScoreboardLayout(
 
         val topScores = ScoreUtils.getTopScoreDistribution(scoreDistribution)
 
+//        val handicap = "Handicap: 34"
+
         val table = Table(false)
         var row: Table.Row = table.startRow()
         for (topScore in topScores) {
             row.addBoldCell(topScore.first!!)
         }
         row.addBoldCell(context.getString(R.string.hits))
-        row.addBoldCell(context.getString(R.string.average))
+        row.addBoldCell(context.getString(R.string.avg_symbol))
+        row.addBoldCell(context.getString(R.string.handicap_symbol))
         row = table.startRow()
 
         for (topScore in topScores) {
@@ -242,6 +245,9 @@ class DefaultScoreboardLayout(
         }
         row.addCell("$hits/$total")
         row.addCell(getAverageScore(scoreDistribution))
+
+        row.addCell("42")
+
         return table
     }
 

--- a/app/src/main/java/de/dreier/mytargets/features/settings/about/AboutFragment.kt
+++ b/app/src/main/java/de/dreier/mytargets/features/settings/about/AboutFragment.kt
@@ -109,19 +109,19 @@ class AboutFragment : Fragment() {
                             + "\n" + getString(R.string.translators), null
                 )
             )
-            .addGroup("Handicap Calculations")
+            .addGroup("Handicap Calculations (" + getString(R.string.handicap_symbol) + ")")
             .addItem(Element(
                     "Original Handicap Calculation and Tables" + "\n" +
                     "   David Lane" + "\n" +
-                    "      Toxophilus 2(1) (1979)" + "\n" +
                     "\n" +
                     "Online Tables Creator and Demystification" + "\n" +
                     "   Jack Atkinson" + "\n" +
-                    "      https://www.jackatkinson.net" + "\n" +
                     "\n" +
                     "Java/Kotlin implementation" + "\n" +
                     "   Jez McKinley" + "\n" +
-                    "      https://canfordmagnabowmen.co.uk/", null)
+                    "\n" +
+                    "See in-app help pages for detailed information",
+                    null)
             )
             .create()
     }

--- a/app/src/main/java/de/dreier/mytargets/features/settings/about/AboutFragment.kt
+++ b/app/src/main/java/de/dreier/mytargets/features/settings/about/AboutFragment.kt
@@ -109,6 +109,20 @@ class AboutFragment : Fragment() {
                             + "\n" + getString(R.string.translators), null
                 )
             )
+            .addGroup("Handicap Calculations")
+            .addItem(Element(
+                    "Original Handicap Calculation and Tables" + "\n" +
+                    "   David Lane" + "\n" +
+                    "      Toxophilus 2(1) (1979)" + "\n" +
+                    "\n" +
+                    "Online Tables Creator and Demystification" + "\n" +
+                    "   Jack Atkinson" + "\n" +
+                    "      https://www.jackatkinson.net" + "\n" +
+                    "\n" +
+                    "Java/Kotlin implementation" + "\n" +
+                    "   Jez McKinley" + "\n" +
+                    "      https://canfordmagnabowmen.co.uk/", null)
+            )
             .create()
     }
 

--- a/app/src/main/java/de/dreier/mytargets/features/statistics/HandicapCalculator.kt
+++ b/app/src/main/java/de/dreier/mytargets/features/statistics/HandicapCalculator.kt
@@ -1,0 +1,69 @@
+package de.dreier.mytargets.features.statistics
+
+import kotlin.math.pow
+
+class HandicapCalculator {
+    private val yards2metres = 0.9144
+
+    private var handicap: Int = 0
+    private var handicapCoefficient: Double = 0.0
+    private var targetDistanceYards: Int = 0
+    private var targetDistanceMetres: Double = 0.0
+    private var isMetric: Boolean = true
+
+
+    fun targetDistanceMetres(): Any {
+        return targetDistanceMetres
+    }
+
+    fun targetDistanceYards(): Any {
+        return targetDistanceYards
+    }
+
+    fun handicap(): Int {
+        return handicap
+    }
+
+    fun handicapCoefficient(): Double {
+        return handicapCoefficient
+    }
+
+    fun setTargetDistanceYards(yards: Int) {
+        this.targetDistanceYards = yards
+        this.targetDistanceMetres = yardsToMetres(yards)
+        this.isMetric = false
+    }
+
+    fun yardsToMetres(yards: Int): Double {
+        return yards * yards2metres
+    }
+
+    fun setTargetDistanceMetres(metres: Int) {
+        this.targetDistanceMetres = metres.toDouble()
+    }
+
+    fun setHandicap(handicap: Int) {
+        this.handicap = handicap
+        this.handicapCoefficient = handicapCoefficient(handicap)
+    }
+
+    fun handicapCoefficient(handicap: Int) :Double {
+        //K=1.429*10^-6 * 1.07^(handicap+4.3)
+        return 1.429*(10.00.pow(-6))*1.07.pow(handicap+4.3)
+    }
+
+    fun dispersionFactor(handicap: Int, distance: Double): Double {
+        //F=1 + 1.429*10^-6 * 1.07^(handicap+4.3) * distance_in_metres^2
+        return 1+1.429*(10.0.pow(-6)) * 1.07.pow(handicap+4.3) * distance.pow(2)
+    }
+
+    fun dispersionFactorYards(handicap: Int, yards: Int): Double {
+        return dispersionFactor(handicap, yardsToMetres(yards))
+    }
+
+    fun isMetric(): Boolean {
+        return isMetric
+
+    }
+
+}

--- a/app/src/main/res/raw/help.html
+++ b/app/src/main/res/raw/help.html
@@ -97,10 +97,34 @@
                     <summary>Statistics elements</summary>
                     <p>In the following the main UI components are described:</p>
                     <ul>
-                        <li><strong>Line chart</strong>: Shows the average score per arrow per end. The orange linear regression line shows the overall trend. The chart can be zoomed by pinching two fingers horizontally.</li>
+                        <li><strong>Line chart</strong>: Shows the average score per arrow per end. The orange linear regression line shows the overall trend. The chart can be zoomed by pinching two fingers horizontally. May be denoted with "Ø" Symbol</li>
                         <li><strong>Distribution chart</strong>: Shows the distribution of arrows amongst the available rings. If no segment is selected, the overall count of hits and misses is shown. By tapping on a segment the exact number of shots in this category is shown.</li>
                         <li><strong>Dispersion pattern</strong>: Shows all shots on a single target face including the selected grouping method (can be changed in the app's settings). If you tap on the dispersion pattern you get a bigger version of the dispersion pattern. From the details screen you can also share the dispersion pattern image or print it.</li>
                         <li><strong>Arrow ranking</strong>: If you have used the arrow numbering feature in one of the selected trainings, the arrow rankings are shown below. The arrows with the best average score are placed at the top of the list. Tapping on an arrow number takes you to a dispersion pattern, which only shows the shots of the selected arrow.</li>
+                        <li><strong>Handicaps</strong>: These are calculated for each distance making up a round and the total for all rounds. May be denoted with "∑" symbol. See next section for more detailed intormation.</li>
+                    </ul>
+                </details>
+                <details>
+                   <summary>Handicaps</summary>
+                    <p>Where used in table summaries with limited space, may be denoted with "∑" symbol.</p>
+                    <p>Note that the calculation is based on a complete round so will *not* be accurate on partly completed rounds currently.</p>
+                    <p>Handicaps are calculated and shown for each round and also for different distances during the round</p>
+                    <p>They are calculated as per the formulae developed by David Lane. His work is documented here:</p>
+                    <ul>
+                        <li>"The Construction of the Graduated Handicap Tables for Target Archery", David Lane, Sep 2013.</li>
+                        <li>"Handicap Tables", David Lane, published in Toxophilus Vol II Number 1 1979</li>
+                        <li>"The variation of accuracy with range", David Lane, published in Toxophilus Vol II Number 3 1979</li>
+                        <li>"The Construction of Handicap Tables for Archers", David Lane, March 1978</li>
+                    </ul>
+                    <p>A simplified explanation of David Lane's work has been done by Jack Atkinson on his blog. Of particular note for this app is his suggested uses for progress tracking along the the critique of using the score allowance for score comparisons</p>
+                    <ul>
+                        <li>"The Archery Handicap System", Jack Atkinson, Apr 2020</li>
+                        <li>https://www.jackatkinson.net/post/archery_handicap/</li>
+                    </ul>
+                    <p>Android implementation for handicaps implemented by Jez McKinley at Canford Magna Bowmen</p>
+                    <ul>
+                        <li>https://www.mckinley.biz/</li>
+                        <li>https://www.canfordmagnabowmen.co.uk/</li>
                     </ul>
                 </details>
                 <details>

--- a/app/src/main/res/raw/help.html
+++ b/app/src/main/res/raw/help.html
@@ -108,6 +108,7 @@
                    <summary>Handicaps</summary>
                     <p>Where used in table summaries with limited space, may be denoted with "∑" symbol.</p>
                     <p>Note that the calculation is based on a complete round so will *not* be accurate on partly completed rounds currently.</p>
+                    <p>Also note that the calculation will vary with arrow diameter. If you have not set this, then it will default to the accepted 'average' spine - 1816 (diameter 7.14mm)</p>
                     <p>Handicaps are calculated and shown for each round and also for different distances during the round</p>
                     <p>They are calculated as per the formulae developed by David Lane. His work is documented here:</p>
                     <ul>

--- a/app/src/main/res/raw/help.html
+++ b/app/src/main/res/raw/help.html
@@ -121,7 +121,7 @@
                         <li>"The Archery Handicap System", Jack Atkinson, Apr 2020</li>
                         <li>https://www.jackatkinson.net/post/archery_handicap/</li>
                     </ul>
-                    <p>Android implementation for handicaps implemented by Jez McKinley at Canford Magna Bowmen</p>
+                    <p>Android implementation for handicaps by Jez McKinley at Canford Magna Bowmen</p>
                     <ul>
                         <li>https://www.mckinley.biz/</li>
                         <li>https://www.canfordmagnabowmen.co.uk/</li>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,8 @@
     <string name="carry">R.Total</string>
     <string name="action_print">Print</string>
     <string name="average">Average</string>
+    <string name="avg_symbol">Ø</string>
+    <string name="handicap_symbol">∑</string>
 
     <!-- Input mode -->
     <string name="comment">Comment</string>

--- a/app/src/test/java/de/dreier/mytargets/utils/HandicapCalculatorTest.kt
+++ b/app/src/test/java/de/dreier/mytargets/utils/HandicapCalculatorTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2018 Florian Dreier
+ *
+ * This file is part of MyTargets.
+ *
+ * Calculations used in this file are courtesy of Jack Atkinson - see:
+ * https://www.jackatkinson.net/post/archery_handicap/
+ * derived from David Lane's Handicap Calcs for Toxophilus 1979
+ *
+ * MyTargets is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * MyTargets is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+package de.dreier.mytargets.utils
+
+import de.dreier.mytargets.features.statistics.HandicapCalculator
+import org.junit.Assert.*
+import org.junit.Test
+
+class HandicapCalculatorTest {
+    //    @Test
+//    fun handicapTestWithNoArrowSet() {
+//        val distance = 70
+//        val score = 252
+//        val unit = HandicapCalculator()
+//        val handicap = unit.setDistance(distance).setScore(score).setTargetSize(122).setZones(10).setInnerRing(false).calculate();
+//        assertEqual()
+//    }
+
+    @Test
+    fun test_set_distance_in_yards_calculates_metres() {
+        val unit = HandicapCalculator()
+        unit.setTargetDistanceYards(15)
+        assertEquals(15, unit.targetDistanceYards())
+        assertEquals(13.716, unit.targetDistanceMetres())
+    }
+
+    @Test
+    fun set_distance_in_yards_also_sets_metric_false() {
+        val unit = HandicapCalculator()
+        unit.setTargetDistanceYards(33)
+        assertFalse(unit.isMetric())
+    }
+
+    @Test
+    fun set_distance_in_metres_does_not_set_yardage() {
+        val unit = HandicapCalculator()
+        unit.setTargetDistanceMetres(18)
+        assertTrue(unit.isMetric())
+        assertEquals(0, unit.targetDistanceYards())
+    }
+
+    @Test
+    fun calculate_handicap_coefficient_for_a_selection() {
+        var unit = HandicapCalculator()
+        assertEquals(0.000005273988009897727, unit.handicapCoefficient(15), 0.0000000001)
+        assertEquals(0.0000286242146685357, unit.handicapCoefficient(40), 0.0000000001)
+        assertEquals(0.001550159776623, unit.handicapCoefficient(99), 0.0000000001)
+    }
+
+    @Test
+    fun set_handicap_calcs_and_sets_coefficient_as_well() {
+        var unit = HandicapCalculator()
+        unit.setHandicap(15)
+        assertEquals(0.000005273988009897727, unit.handicapCoefficient(), 0.0000000001)
+    }
+
+    @Test
+    fun dispersion_factor_calcs_at_18_metres() {
+        var unit = HandicapCalculator()
+
+        assertEquals(1.000662691287247, unit.dispersionFactor(1, 18.0), 0.0000000000001)
+        assertEquals(1.00539769534959, unit.dispersionFactor(32, 18.0), 0.0000000000001)
+        assertEquals(1.15900004719565, unit.dispersionFactor(82, 18.0), 0.0000000000001)
+
+    }
+
+    @Test
+    fun dispersion_factor_calcs_at_50_metres() {
+        var unit = HandicapCalculator()
+
+        assertEquals(1.0062640842793422, unit.dispersionFactor(4, 50.0), 0.0000000000001)
+        assertEquals(1.2260465117422445, unit.dispersionFactor(57, 50.0), 0.0000000000001)
+        assertEquals(4.384923959784047, unit.dispersionFactor(97, 50.0), 0.0000000000001)
+
+    }
+
+    @Test
+    fun dispersion_factor_calcs_at_70_yards_does_metric_conversion() {
+        //70y == 64.008m
+        var unit = HandicapCalculator()
+
+        assertEquals(1.00783160883481, unit.dispersionFactorYards(0, 70), 0.0000000000001)
+        assertEquals(1.03469717341738, unit.dispersionFactorYards(22, 70), 0.0000000000001)
+        assertEquals(1.34621233577242, unit.dispersionFactorYards(56, 70), 0.0000000000001)
+        assertEquals(3.01057722079535, unit.dispersionFactorYards(82, 70), 0.0000000000001)
+
+    }
+
+
+}
+
+
+//Angular_Deviation=(1.036^(handicap+12.9))*5*(10^-4)*180/PI()
+//Sigma==100*distance_in_metres*(1.036^(handicap+12.9))*5*(10^-4)*F_from_above
+//Inverse_Angular_Deviation=1/Angular_Deviation
+//
+//$D$7=arrow_diameter_cm  (0.357cm) 18/64
+//$D$7=target_size_cm (122)
+//$D$8=distance_m (70)
+//
+
+//15y=13.716m
+
+//10-zone-Average_Arrow_Score=10 - (EXP(-(((1*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((2*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((3*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((4*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((5*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((6*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((7*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((8*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((9*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((10*$D$7/20)+$D$6)^2)/$F26^2))
+//5-zone-avg-arrow=10 - (EXP(-(((1*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((2*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((3*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((4*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((5*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((6*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((7*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((8*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((9*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((10*$D$7/20)+$D$6)^2)/$F26^2))
+//10-zone-trispot==10 - (EXP(-(((1*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((2*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((3*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((4*$D$7/20)+$D$6)^2)/$F15^2)) - 6* EXP(-(((5*$D$7/20)+$D$6)^2)/$F15^2)
+//10-zone-compound-wa-pmoth=10 - (EXP(-(((1*$D$7/40)+$D$6)^2)/$F15^2) + EXP(-(((2*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((3*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((4*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((5*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((6*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((7*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((8*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((9*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((10*$D$7/20)+$D$6)^2)/$F15^2))
+//6-zone-fita=10 - (EXP(-(((1*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((2*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((3*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((4*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((5*$D$7/20)+$D$6)^2)/$F15^2)) - 5* EXP(-(((6*$D$7/20)+$D$6)^2)/$F15^2)
+//worcester=5 - (EXP(-(((1*$D$7/10)+$D$6)^2)/$F15^2) + EXP(-(((2*$D$7/10)+$D$6)^2)/$F15^2) + EXP(-(((3*$D$7/10)+$D$6)^2)/$F15^2) + EXP(-(((4*$D$7/10)+$D$6)^2)/$F15^2) + EXP(-(((5*$D$7/10)+$D$6)^2)/$F15^2))
+//wa-field=6 - EXP(-(((1*$D$7/20)+$D$6)^2)/$F15^2) - (EXP(-(((2*$D$7/10)+$D$6)^2)/$F15^2) + EXP(-(((3*$D$7/10)+$D$6)^2)/$F15^2) + EXP(-(((4*$D$7/10)+$D$6)^2)/$F15^2) + EXP(-(((5*$D$7/10)+$D$6)^2)/$F15^2))
+//beiter-hit-miss=1 - EXP(-(((1*$D$7/2)+$D$6)^2)/$F15^2)
+
+
+
+//Portsmouth
+//Handicap	K	F	Angular deviation (degrees)	Sigma = cm dev (Group radius)	Inverse Angular Deviation		Average Arrow Score	6 Arrows	1 Doz	2.5 Doz	3 Doz	5 Doz	6 Doz	Average Arrow Score	6 Arrows	1 Doz	2 Doz	3 Doz	4 Doz	6 Doz	Average Arrow Score	6 Arrows	1 Doz	2.5 Doz	5 Doz	Average Arrow Score	6 Arrows	Dozen	2.5 Dozen	5 Dozen	Average Arrow Score	6 Arrows	Dozen	2.5 Doz	5 Dozen	Average Arrow Score	6 Arrows	Dozen	3 Doz	6 Dozen	Average Arrow Score	6 Arrows	Dozen	2.5 Doz	5 Dozen	Average Arrow Score	3 Arrows	Average Arrow Score	3 Arrows	6 Arrows	30 Arrows
+//0	1.91153596182896E-06	1.00061933765163	0.0452098932	1.42119034	22.12		10.00	60	120	300	360	600	720	9.00	54	108	216	324	432	648	10.00	60	120	300	600	9.82	59	118	295	589	9.82	59	118	295	589	10.00	60	120	360	720	5.00	30	60	150	300	6.00	18	1.00	3	6	30
+//15	5.27398800989773E-06	1.00170877211521	0.0768475122	2.41836118	13.01		9.85	59	118	296	355	591	709	9.00	54	108	216	324	432	648	9.85	59	118	296	591	9.44	57	113	283	567	9.44	57	113	283	567	9.85	59	118	355	709	5.00	30	60	150	300	5.85	18	1.00	3	6	30
+//37	2.33658856615937E-05	1.00757054695436	0.1673186808	5.29626575	5.98		9.05	54	109	271	326	543	651	8.52	51	102	204	307	409	613	9.04	54	109	271	543	8.83	53	106	265	530	8.83	53	106	265	530	9.05	54	109	326	651	4.76	29	57	143	286	5.33	16	1.00	3	6	30
+//86	0.000643261195845	1.20841662745386	0.9466129614	35.93676766	1.06		2.23	13	27	67	80	134	160	1.99	12	24	48	72	96	143	1.22	7	15	37	73	2.22	13	27	67	133	1.21	7	15	36	73	1.53	9	18	55	110	1.25	8	15	38	75	2.23	7	0.51	2	3	15
+//100	0.001658670960986	1.53740939135956	1.5531343412	75.01505375	0.64		0.60	4	7	18	22	36	43	0.54	3	6	13	19	26	39	0.30	2	4	9	18	0.60	4	7	18	36	0.30	2	4	9	18	0.38	2	5	14	28	0.34	2	4	10	21	1.34	4	0.15	0	1	5
+
+//70m
+//AGB Adult Classifications	Handicap	K	F	Angular deviation (degrees)	Sigma = cm dev (Group radius)	Inverse Angular Deviation		Average Arrow Score	6 Arrows	1 Doz	2.5 Doz	3 Doz	5 Doz	6 Doz	Average Arrow Score	6 Arrows	1 Doz	2 Doz	3 Doz	4 Doz	6 Doz	Average Arrow Score	6 Arrows	1 Doz	2.5 Doz	5 Doz	Average Arrow Score	6 Arrows	Dozen	2.5 Dozen	5 Dozen	Average Arrow Score	6 Arrows	Dozen	2.5 Doz	5 Dozen	Average Arrow Score	6 Arrows	Dozen	3 Doz	6 Dozen	Average Arrow Score	6 Arrows	Dozen	2.5 Doz	5 Dozen	Average Arrow Score	3 Arrows	Average Arrow Score	3 Arrows	6 Arrows	30 Arrows
+//1	2.04534347915699E-06	1.01002218304787	0.0468374494	5.77962361	21.35		9.70	58	116	291	349	582	699	8.98	54	108	216	323	431	647	9.70	58	116	291	582	9.28	56	111	279	557	9.28	56	111	279	557	9.70	58	116	349	699	4.99	30	60	150	299	5.71	17	1.00	3	6	30
+//GL-GMB	52	6.44672155170852E-05	1.31588935603372	0.2844073153	45.72308703	3.52		4.22	25	51	127	152	253	304	3.82	23	46	92	137	183	275	2.69	16	32	81	162	4.21	25	50	126	252	2.68	16	32	80	161	3.26	20	39	118	235	2.33	14	28	70	140	3.27	10	0.83	3	5	25
+//LL-MB	62	0.000126816770505	1.62140217547505	0.4050776827	80.24250461	2.47		1.89	11	23	57	68	113	136	1.68	10	20	40	61	81	121	1.00	6	12	30	60	1.88	11	23	56	113	0.99	6	12	30	60	1.27	8	15	46	91	1.06	6	13	32	64	2.04	6	0.44	1	3	13
+//GB-3, LB-2	71	0.000233147460024	2.14242255412004	0.5568985865	145.76614046	1.80		0.65	4	8	19	23	39	47	0.57	3	7	14	21	28	41	0.32	2	4	10	19	0.65	4	8	19	39	0.32	2	4	9	19	0.41	2	5	15	29	0.37	2	4	11	22	1.36	4	0.16	0	1	5
+//99	0.001550159776623	8.59578290545124	1.4991644220	1574.38199015	0.67		0.01	0	0	0	0	0	0	0.01	0	0	0	0	0	0	0.00	0	0	0	0	0.01	0	0	0	0	0.00	0	0	0	0	0.00	0	0	0	0	0.00	0	0	0	0	1.00	3	0.00	0	0	0

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -68,5 +68,7 @@ dependencies {
     testImplementation dependencies.mockito
     testImplementation dependencies.truth
     androidTestImplementation dependencies.runner
+    androidTestImplementation 'androidx.test:core:1.1.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
     implementation dependencies.kotlinStdlibJdk7
 }

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/DAIR3DTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/DAIR3DTest.kt
@@ -15,11 +15,10 @@
 
 package de.dreier.mytargets.shared.targets.models
 
+import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry
-import android.support.test.filters.SmallTest
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.runner.AndroidJUnit4
 import de.dreier.mytargets.shared.SharedApplicationInstance
-
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -34,7 +33,7 @@ class DAIR3DTest {
     @Before
     @Throws(Exception::class)
     fun setUp() {
-        SharedApplicationInstance.context = InstrumentationRegistry.getContext()
+        SharedApplicationInstance.context = InstrumentationRegistry.getInstrumentation().targetContext
     }
 
     @Test

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -255,7 +255,6 @@ class HandicapCalculatorTest {
         assertBigDecimalEquals(BigDecimal("0.9617396800"), unit.averageArrowScore())
     }
 
-    @Ignore
     @Test
     fun get_average_arrow_for_handicap_5_zone_imperial() {
         // should we use Target instead of TargetModelBase as this has size and scorestyle bound?
@@ -268,24 +267,42 @@ class HandicapCalculatorTest {
         unit.setHandicap(36)
         unit.setTargetSizeIndex(4)
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("6.88"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("6.8828612028"), unit.averageArrowScore())
 
         // 122cm, 80y (73.152m)
         unit.setHandicap(36)
         unit.setTargetSizeIndex(4)
         unit.setTargetDistance(Dimension(80.0f, Dimension.Unit.YARDS))
-        assertBigDecimalEquals(BigDecimal("6.71"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("6.7122001518"), unit.averageArrowScore())
 
         // 60cm, 18m
         unit.setHandicap(26)
         unit.setTargetSizeIndex(1)
         unit.setTargetDistance(Dimension(18.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("8.92"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("8.9152743398"), unit.averageArrowScore())
 
     }
 
+    @Ignore
+    @Test
     fun test_with_different_arrow_diameter() {
-        assertEquals(1,1)
+
+        var unit = HandicapCalculator()
+        unit.setTargetModel(WAFull())
+        unit.setScoringStyleIndex(2)
+        unit.setArrowRadius(BigDecimal("4.5641"))
+
+        // 122cm, 80y (73.152m)
+        unit.setHandicap(36)
+        unit.setTargetSizeIndex(4)
+        unit.setTargetDistance(Dimension(80.0f, Dimension.Unit.YARDS))
+        assertBigDecimalEquals(BigDecimal("6.7122001518"), unit.averageArrowScore())
+
+        // 60cm, 18m
+        unit.setHandicap(26)
+        unit.setTargetSizeIndex(1)
+        unit.setTargetDistance(Dimension(18.0f, Dimension.Unit.METER))
+        assertBigDecimalEquals(BigDecimal("8.9152743398"), unit.averageArrowScore())
     }
 }
 

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -87,8 +87,7 @@ class HandicapCalculatorTest {
     @Test
     fun set_handicap_calcs_and_sets_coefficient_as_well() {
         var unit = HandicapCalculator()
-        unit.setHandicap(15)
-        assertEquals(0.000005273988009897727, unit.handicapCoefficient(), 0.0000000001)
+        assertEquals(0.000005273988009897727, unit.handicapCoefficient(15), 0.0000000001)
     }
 
     @Test
@@ -96,12 +95,9 @@ class HandicapCalculatorTest {
         var unit = HandicapCalculator()
         unit.setTargetDistance(Dimension(18f, Dimension.Unit.METER))
 
-        unit.setHandicap(1)
-        assertBigDecimalEquals(BigDecimal(1.000662691287247), unit.dispersionFactor())
-        unit.setHandicap(32)
-        assertBigDecimalEquals(BigDecimal(1.00539769534959), unit.dispersionFactor())
-        unit.setHandicap(82)
-        assertBigDecimalEquals(BigDecimal(1.15900004719565), unit.dispersionFactor())
+        assertBigDecimalEquals(BigDecimal(1.000662691287247), unit.dispersionFactor(1))
+        assertBigDecimalEquals(BigDecimal(1.00539769534959), unit.dispersionFactor(32))
+        assertBigDecimalEquals(BigDecimal(1.15900004719565), unit.dispersionFactor(82))
 
     }
 
@@ -110,12 +106,9 @@ class HandicapCalculatorTest {
         var unit = HandicapCalculator()
         unit.setTargetDistance(Dimension(50f, Dimension.Unit.METER))
 
-        unit.setHandicap(4)
-        assertBigDecimalEquals(BigDecimal(1.0062640842793422), unit.dispersionFactor())
-        unit.setHandicap(57)
-        assertBigDecimalEquals(BigDecimal(1.2260465117422445), unit.dispersionFactor())
-        unit.setHandicap(97)
-        assertBigDecimalEquals(BigDecimal(4.384923959784047), unit.dispersionFactor())
+        assertBigDecimalEquals(BigDecimal(1.0062640842793422), unit.dispersionFactor(4))
+        assertBigDecimalEquals(BigDecimal(1.2260465117422445), unit.dispersionFactor(57))
+        assertBigDecimalEquals(BigDecimal(4.384923959784047), unit.dispersionFactor(97))
 
     }
 
@@ -167,34 +160,27 @@ class HandicapCalculatorTest {
     @Test
     fun get_angular_deviation_for_handicap() {
         var unit = HandicapCalculator()
-        unit.setHandicap(8)
-        assertBigDecimalEquals(BigDecimal("0.0599945120"), unit.angularDeviation())
-        unit.setHandicap(45)
-        assertBigDecimalEquals(BigDecimal("0.2220355297"), unit.angularDeviation())
-        unit.setHandicap(82)
-        assertBigDecimalEquals(BigDecimal("0.8217381029"), unit.angularDeviation())
+        assertBigDecimalEquals(BigDecimal("0.0599945120"), unit.angularDeviation(8))
+        assertBigDecimalEquals(BigDecimal("0.2220355297"), unit.angularDeviation(45))
+        assertBigDecimalEquals(BigDecimal("0.8217381029"), unit.angularDeviation(82))
     }
 
     @Test
     fun get_group_radius() {
         var unit = HandicapCalculator()
-        unit.setHandicap(8)
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("7.4476726237"), unit.groupRadius())
-        unit.setHandicap(45)
+        assertBigDecimalEquals(BigDecimal("7.4476726237"), unit.groupRadius(8))
         unit.setTargetDistance(Dimension(40.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("16.4967128591"), unit.groupRadius())
-        unit.setHandicap(82)
+        assertBigDecimalEquals(BigDecimal("16.4967128591"), unit.groupRadius(45))
         unit.setTargetDistance(Dimension(20.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("34.3146495334"), unit.groupRadius())
+        assertBigDecimalEquals(BigDecimal("34.3146495334"), unit.groupRadius(82))
     }
 
     @Test
     fun get_group_radius_imperial() {
         var unit = HandicapCalculator()
-        unit.setHandicap(55)
         unit.setTargetDistance(Dimension(60.0f, Dimension.Unit.YARDS))
-        assertBigDecimalEquals(BigDecimal("37.4808083757"), unit.groupRadius())
+        assertBigDecimalEquals(BigDecimal("37.4808083757"), unit.groupRadius(55))
         // TODO - check this calc - may just be imperial rounding error
 //        assertBigDecimalEquals(BigDecimal.valueOf(37.48065477), unit.groupRadius())
     }
@@ -209,22 +195,19 @@ class HandicapCalculatorTest {
         unit.setScoringStyleIndex(1)
 
        // 122cm, 70m
-        unit.setHandicap(18)
         unit.setTargetSizeIndex(4)
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("8.9900035590"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("8.9900035590"), unit.averageArrowScoreForHandicap(18))
 
         // 80cm, 60m
-        unit.setHandicap(45)
         unit.setTargetSizeIndex(2)
         unit.setTargetDistance(Dimension(60.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("4.8349706596"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("4.8349706596"), unit.averageArrowScoreForHandicap(45))
 
         // 40cm, 40m
-        unit.setHandicap(82)
         unit.setTargetSizeIndex(0)
         unit.setTargetDistance(Dimension(40.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("0.1524555998"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("0.1524555998"), unit.averageArrowScoreForHandicap(82))
     }
 
     @Test
@@ -236,22 +219,19 @@ class HandicapCalculatorTest {
         unit.setScoringStyleIndex(2)
 
         // 122cm, 70m
-        unit.setHandicap(41)
         unit.setTargetSizeIndex(4)
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("6.5866551614"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("6.5866551614"), unit.averageArrowScoreForHandicap(41))
 
         // 80cm, 60m
-        unit.setHandicap(11)
         unit.setTargetSizeIndex(2)
         unit.setTargetDistance(Dimension(60.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("8.8028056795"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("8.8028056795"), unit.averageArrowScoreForHandicap(11))
 
         // 40cm, 40m
-        unit.setHandicap(65)
         unit.setTargetSizeIndex(0)
         unit.setTargetDistance(Dimension(40.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("0.9617396800"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("0.9617396800"), unit.averageArrowScoreForHandicap(65))
     }
 
     @Test
@@ -263,22 +243,19 @@ class HandicapCalculatorTest {
         unit.setScoringStyleIndex(5)
 
         // 122cm, 70m
-        unit.setHandicap(36)
         unit.setTargetSizeIndex(4)
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("6.8828612028"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("6.8828612028"), unit.averageArrowScoreForHandicap(36))
 
         // 122cm, 80y (73.152m)
-        unit.setHandicap(36)
         unit.setTargetSizeIndex(4)
         unit.setTargetDistance(Dimension(80.0f, Dimension.Unit.YARDS))
-        assertBigDecimalEquals(BigDecimal("6.7122001518"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("6.7122001518"), unit.averageArrowScoreForHandicap(36))
 
         // 60cm, 18m
-        unit.setHandicap(26)
         unit.setTargetSizeIndex(1)
         unit.setTargetDistance(Dimension(18.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("8.9152743398"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("8.9152743398"), unit.averageArrowScoreForHandicap(26))
 
     }
 
@@ -291,16 +268,14 @@ class HandicapCalculatorTest {
         unit.setArrowRadius(BigDecimal("0.4564"))
 
         // 122cm, 70m
-        unit.setHandicap(49)
         unit.setTargetSizeIndex(4)
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("4.9782780054"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("4.9782780054"), unit.averageArrowScoreForHandicap(49))
 
         // 60cm, 18m
-        unit.setHandicap(26)
         unit.setTargetSizeIndex(1)
         unit.setTargetDistance(Dimension(18.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("9.5680222762"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("9.5680222762"), unit.averageArrowScoreForHandicap(26))
     }
 }
 

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -1,7 +1,7 @@
 /*
  * MyTargets Project Copyright (C) 2018 Florian Dreier
  *
- * This file is (c) 2021 Jez McKinley
+ * This file is (c) 2021 Jez McKinley - Canford Magna Bowmen
  *
  * Calculations used in this file are courtesy of Jack Atkinson - see:
  * https://www.jackatkinson.net/post/archery_handicap/

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -17,13 +17,25 @@
  * GNU General Public License for more details.
  */
 
-package de.dreier.mytargets.utils
+package de.dreier.mytargets.shared.targets.models
 
-import de.dreier.mytargets.features.statistics.HandicapCalculator
+import android.content.Context
+import androidx.test.filters.SmallTest
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
+import de.dreier.mytargets.shared.SharedApplicationInstance
+import de.dreier.mytargets.shared.models.HandicapCalculator
+import org.junit.Assert
 import org.junit.Assert.*
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@SmallTest
+@RunWith(AndroidJUnit4::class)
 class HandicapCalculatorTest {
+    private lateinit var context: Context
+
     //    @Test
 //    fun handicapTestWithNoArrowSet() {
 //        val distance = 70
@@ -32,6 +44,14 @@ class HandicapCalculatorTest {
 //        val handicap = unit.setDistance(distance).setScore(score).setTargetSize(122).setZones(10).setInnerRing(false).calculate();
 //        assertEqual()
 //    }
+
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        SharedApplicationInstance.context = InstrumentationRegistry.getInstrumentation().targetContext
+    }
+
 
     @Test
     fun test_set_distance_in_yards_calculates_metres() {
@@ -103,29 +123,43 @@ class HandicapCalculatorTest {
 
     }
 
+    @Test
+    fun ten_zone_average_calc() {
+//        var unit = HandicapCalculator()
+//        assertEquals(1.00783160883481, unit.averageArrowScore(10, 70), 0.0000000000001)
+        var instance = SharedApplicationInstance()
+
+        var target = WAFull()
+        Assert.assertEquals(10, target.getScoringStyle(0).getPointsByScoringRing(0, 0).toLong())
+
+        assertEquals(11, target.zoneCount)
+    }
+
 
 }
 
 
+
+
 //Angular_Deviation=(1.036^(handicap+12.9))*5*(10^-4)*180/PI()
-//Sigma==100*distance_in_metres*(1.036^(handicap+12.9))*5*(10^-4)*F_from_above
+//sigma=groupRadiusCm==100*distance_in_metres*(1.036^(handicap+12.9))*5*(10^-4)*F_from_above
 //Inverse_Angular_Deviation=1/Angular_Deviation
 //
-//$D$7=arrow_diameter_cm  (0.357cm) 18/64
-//$D$7=target_size_cm (122)
-//$D$8=distance_m (70)
+//arrowDiameterCm=arrow_diameter_cm  (0.357cm) 18/64
+//targetSizeCm=target_size_cm (122)
+//targetDistanceMetres=distance_m (70)
 //
 
 //15y=13.716m
 
-//10-zone-Average_Arrow_Score=10 - (EXP(-(((1*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((2*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((3*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((4*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((5*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((6*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((7*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((8*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((9*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((10*$D$7/20)+$D$6)^2)/$F26^2))
-//5-zone-avg-arrow=10 - (EXP(-(((1*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((2*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((3*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((4*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((5*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((6*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((7*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((8*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((9*$D$7/20)+$D$6)^2)/$F26^2) + EXP(-(((10*$D$7/20)+$D$6)^2)/$F26^2))
-//10-zone-trispot==10 - (EXP(-(((1*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((2*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((3*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((4*$D$7/20)+$D$6)^2)/$F15^2)) - 6* EXP(-(((5*$D$7/20)+$D$6)^2)/$F15^2)
-//10-zone-compound-wa-pmoth=10 - (EXP(-(((1*$D$7/40)+$D$6)^2)/$F15^2) + EXP(-(((2*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((3*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((4*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((5*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((6*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((7*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((8*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((9*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((10*$D$7/20)+$D$6)^2)/$F15^2))
-//6-zone-fita=10 - (EXP(-(((1*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((2*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((3*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((4*$D$7/20)+$D$6)^2)/$F15^2) + EXP(-(((5*$D$7/20)+$D$6)^2)/$F15^2)) - 5* EXP(-(((6*$D$7/20)+$D$6)^2)/$F15^2)
-//worcester=5 - (EXP(-(((1*$D$7/10)+$D$6)^2)/$F15^2) + EXP(-(((2*$D$7/10)+$D$6)^2)/$F15^2) + EXP(-(((3*$D$7/10)+$D$6)^2)/$F15^2) + EXP(-(((4*$D$7/10)+$D$6)^2)/$F15^2) + EXP(-(((5*$D$7/10)+$D$6)^2)/$F15^2))
-//wa-field=6 - EXP(-(((1*$D$7/20)+$D$6)^2)/$F15^2) - (EXP(-(((2*$D$7/10)+$D$6)^2)/$F15^2) + EXP(-(((3*$D$7/10)+$D$6)^2)/$F15^2) + EXP(-(((4*$D$7/10)+$D$6)^2)/$F15^2) + EXP(-(((5*$D$7/10)+$D$6)^2)/$F15^2))
-//beiter-hit-miss=1 - EXP(-(((1*$D$7/2)+$D$6)^2)/$F15^2)
+//10-zone-Average_Arrow_Score=10 - (EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((7*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((8*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((9*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((10*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2))
+//5-zone-avg-arrow==9 - 2*(EXP(-(((1*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2)) - EXP(-(((5*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2)
+//10-zone-trispot==10 - (EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2)) - 6* EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2)
+//10-zone-compound-wa-pmoth=10 - (EXP(-(((1*targetSizeCm/40)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((7*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((8*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((9*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((10*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2))
+//6-zone-fita=10 - (EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2)) - 5* EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2)
+//worcester=5 - (EXP(-(((1*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2))
+//wa-field=6 - EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) - (EXP(-(((2*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2))
+//beiter-hit-miss=1 - EXP(-(((1*targetSizeCm/2)+arrowDiameterCm)^2)/groupRadiusCm^2)
 
 
 

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -366,7 +366,7 @@ class HandicapCalculatorTest {
         var distance = Dimension(70f, Dimension.Unit.METER)
         var diameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var target = Target(WAFull.ID, 1,  diameter)
-        var score = Score(222)
+        var score = Score(222, 720)
         var round = Round(0, 0, 0, 6, 6, distance, "test", target, score )
 
         var unit = HandicapCalculator(round)
@@ -380,9 +380,10 @@ class HandicapCalculatorTest {
         assertThat(unit.targetDistance.value, equalTo(70f))
         assertThat(unit.targetDistance.unit, equalTo(Dimension.Unit.METER))
         assertThat(unit.metricDistance, equalTo(BigDecimal("70.0")))
-        assertThat(unit.scoreForRound, equalTo(222))
+        assertThat(unit.maxScore, equalTo(720))
+        assertThat(unit.reachedScore, equalTo(222))
 
-        assertThat(unit.getHandicapForScore(round.score.totalPoints), equalTo(44))
+        assertThat(unit.getHandicapForScore(round.score.reachedPoints), equalTo(44))
         assertThat(unit.getHandicap(), equalTo(44))
     }
 
@@ -392,7 +393,7 @@ class HandicapCalculatorTest {
         var distance = Dimension(76.5529f, Dimension.Unit.YARDS)
         var diameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var target = Target(WAFull.ID, 0,  diameter)
-        var score = Score(341)
+        var score = Score(341, 999)
         var round = Round(0, 0, 0, 6, 12, distance, "test", target, score )
 
         var unit = HandicapCalculator(round)
@@ -400,7 +401,7 @@ class HandicapCalculatorTest {
         assertThat(unit.targetDistance.value, equalTo(76.5529f))
         assertThat(unit.targetDistance.unit, equalTo(Dimension.Unit.YARDS))
 
-        assertThat(unit.getHandicapForScore(round.score.totalPoints), equalTo(50))
+        assertThat(unit.getHandicapForScore(round.score.reachedPoints), equalTo(50))
     }
 
     @Test
@@ -409,7 +410,7 @@ class HandicapCalculatorTest {
         var distance = Dimension(70f, Dimension.Unit.METER)
         var diameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var target = Target(WAFull.ID, 0, diameter)
-        var score = Score(647)
+        var score = Score(647, 720)
         var round = Round(0, 0, 0, 6, 12, distance, "test", target, score)
 
         var unit = HandicapCalculator(round)

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -185,7 +185,7 @@ class HandicapCalculatorTest {
         // Should be 122 target 70m
         var unit = HandicapCalculator()
         unit.setTargetModel(WAFull())
-        unit.setScoringStyleIndex(1)
+        unit.setScoringStyle(WAFull().getScoringStyle(1))
 
        // 122cm, 70m
         unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
@@ -209,7 +209,7 @@ class HandicapCalculatorTest {
         // Should be 122 target 70m
         var unit = HandicapCalculator()
         unit.setTargetModel(WAFull())
-        unit.setScoringStyleIndex(2)
+        unit.setScoringStyle(WAFull().getScoringStyle(2))
 
         // 122cm, 70m
         unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
@@ -233,7 +233,7 @@ class HandicapCalculatorTest {
         // Should be 122 target 70m
         var unit = HandicapCalculator()
         unit.setTargetModel(WAFull())
-        unit.setScoringStyleIndex(5)
+        unit.setScoringStyle(WAFull().getScoringStyle(5))
 
         // 122cm, 70m
         unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
@@ -257,7 +257,7 @@ class HandicapCalculatorTest {
 
         var unit = HandicapCalculator()
         unit.setTargetModel(WAFull())
-        unit.setScoringStyleIndex(1)
+        unit.setScoringStyle(WAFull().getScoringStyle(1))
         unit.setArrowRadius(BigDecimal("0.4564"))
 
         // 122cm, 70m
@@ -278,7 +278,7 @@ class HandicapCalculatorTest {
         unit.setTargetModel(WAFull())
 
         // 122cm, 70m, WA Metric Recurve
-        unit.setScoringStyleIndex(1)
+        unit.setScoringStyle(WAFull().getScoringStyle(1))
         unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
 
@@ -298,7 +298,7 @@ class HandicapCalculatorTest {
         unit.setTargetModel(WAFull())
 
         // 122cm, 70m, WA Metric Recurve
-        unit.setScoringStyleIndex(1)
+        unit.setScoringStyle(WAFull().getScoringStyle(1))
         unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
 
@@ -319,7 +319,7 @@ class HandicapCalculatorTest {
         unit.setTargetModel(WAFull())
 
         // 122cm, 70m, WA Metric Recurve
-        unit.setScoringStyleIndex(1)
+        unit.setScoringStyle(WAFull().getScoringStyle(1))
         unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
 //        unit.setTargetDistance(Dimension(45.72f, Dimension.Unit.METER))
         unit.setTargetDistance(Dimension(76.5529f, Dimension.Unit.YARDS))
@@ -344,7 +344,7 @@ class HandicapCalculatorTest {
 
         assertThat(unit.arrowRadius, equalTo(BigDecimal("0.357")))
         assertThat(unit.targetModel, notNullValue())
-        assertThat(unit.scoringStyleIndex, equalTo(1))
+        assertThat(unit.scoringStyle.title, equalTo(WAFull().getScoringStyle(1).title))
         assertThat(unit.arrowCount, equalTo(36))
         assertThat(unit.targetSize.value, equalTo(122f))
         assertThat(unit.targetSize.unit, equalTo(Dimension.Unit.CENTIMETER))

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -71,8 +71,9 @@ class HandicapCalculatorTest {
     fun test_set_distance_in_yards_calculates_metres() {
         val unit = HandicapCalculator()
         unit.setTargetDistance(Dimension(15f, Dimension.Unit.YARDS))
-        assertBigDecimalEquals(BigDecimal.valueOf(13.716), unit.metricDistance(), scale = 3)
         assertEquals(Dimension.Unit.YARDS, unit.targetDistance().unit)
+        assertEquals(15f, unit.targetDistance().value)
+        assertBigDecimalEquals(BigDecimal.valueOf(13.716), unit.metricDistance(), scale = 3)
     }
 
     @Test
@@ -93,20 +94,28 @@ class HandicapCalculatorTest {
     @Test
     fun dispersion_factor_calcs_at_18_metres() {
         var unit = HandicapCalculator()
+        unit.setTargetDistance(Dimension(18f, Dimension.Unit.METER))
 
-        assertBigDecimalEquals(BigDecimal(1.000662691287247), unit.dispersionFactor(1, BigDecimal(18.0)))
-        assertBigDecimalEquals(BigDecimal(1.00539769534959), unit.dispersionFactor(32, BigDecimal(18.0)))
-        assertBigDecimalEquals(BigDecimal(1.15900004719565), unit.dispersionFactor(82, BigDecimal(18.0)))
+        unit.setHandicap(1)
+        assertBigDecimalEquals(BigDecimal(1.000662691287247), unit.dispersionFactor())
+        unit.setHandicap(32)
+        assertBigDecimalEquals(BigDecimal(1.00539769534959), unit.dispersionFactor())
+        unit.setHandicap(82)
+        assertBigDecimalEquals(BigDecimal(1.15900004719565), unit.dispersionFactor())
 
     }
 
     @Test
     fun dispersion_factor_calcs_at_50_metres() {
         var unit = HandicapCalculator()
+        unit.setTargetDistance(Dimension(50f, Dimension.Unit.METER))
 
-        assertBigDecimalEquals(BigDecimal(1.0062640842793422), unit.dispersionFactor(4, BigDecimal(50.0)))
-        assertBigDecimalEquals(BigDecimal(1.2260465117422445), unit.dispersionFactor(57, BigDecimal(50.0)))
-        assertBigDecimalEquals(BigDecimal(4.384923959784047), unit.dispersionFactor(97, BigDecimal(50.0)))
+        unit.setHandicap(4)
+        assertBigDecimalEquals(BigDecimal(1.0062640842793422), unit.dispersionFactor())
+        unit.setHandicap(57)
+        assertBigDecimalEquals(BigDecimal(1.2260465117422445), unit.dispersionFactor())
+        unit.setHandicap(97)
+        assertBigDecimalEquals(BigDecimal(4.384923959784047), unit.dispersionFactor())
 
     }
 
@@ -185,6 +194,7 @@ class HandicapCalculatorTest {
         // TODO - check this calc - may just be imperial rounding error
 //        assertBigDecimalEquals(BigDecimal.valueOf(37.48065477), unit.groupRadius())
     }
+    // https://dzone.com/articles/never-use-float-and-double-for-monetary-calculatio
 }
 
 

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -277,6 +277,46 @@ class HandicapCalculatorTest {
         unit.setTargetDistance(Dimension(18.0f, Dimension.Unit.METER))
         assertBigDecimalEquals(BigDecimal("9.5680222762"), unit.averageArrowScoreForHandicap(26))
     }
+
+    @Test
+    fun test_handicap_list() {
+
+        var unit = HandicapCalculator()
+        unit.setTargetModel(WAFull())
+
+        // 122cm, 70m, WA Metric Recurve
+        unit.setScoringStyleIndex(1)
+        unit.setTargetSizeIndex(4)
+        unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
+
+        unit.setArrowCount(36)
+        var handicapList = unit.handicapScoresList()
+
+        assertEquals(101, handicapList.size)
+
+        assertEquals(324, handicapList.get(18))
+        assertEquals(233, handicapList.get(42))
+        assertEquals(35, handicapList.get(68))
+    }
+
+    @Test
+    fun test_get_handicap_for_score() {
+        var unit = HandicapCalculator()
+        unit.setTargetModel(WAFull())
+
+        // 122cm, 70m, WA Metric Recurve
+        unit.setScoringStyleIndex(1)
+        unit.setTargetSizeIndex(4)
+        unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
+
+        unit.setArrowCount(72)
+
+        assertEquals(10, unit.getHandicap(677))
+        assertEquals(10, unit.getHandicap(678))
+        assertEquals(10, unit.getHandicap(679))
+        assertEquals(9, unit.getHandicap(680))
+
+    }
 }
 
 

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -94,9 +94,9 @@ class HandicapCalculatorTest {
     fun dispersion_factor_calcs_at_18_metres() {
         var unit = HandicapCalculator()
 
-        assertEquals(1.000662691287247, unit.dispersionFactor(1, 18.0), 0.0000000000001)
-        assertEquals(1.00539769534959, unit.dispersionFactor(32, 18.0), 0.0000000000001)
-        assertEquals(1.15900004719565, unit.dispersionFactor(82, 18.0), 0.0000000000001)
+        assertBigDecimalEquals(BigDecimal(1.000662691287247), unit.dispersionFactor(1, BigDecimal(18.0)))
+        assertBigDecimalEquals(BigDecimal(1.00539769534959), unit.dispersionFactor(32, BigDecimal(18.0)))
+        assertBigDecimalEquals(BigDecimal(1.15900004719565), unit.dispersionFactor(82, BigDecimal(18.0)))
 
     }
 
@@ -104,21 +104,9 @@ class HandicapCalculatorTest {
     fun dispersion_factor_calcs_at_50_metres() {
         var unit = HandicapCalculator()
 
-        assertEquals(1.0062640842793422, unit.dispersionFactor(4, 50.0), 0.0000000000001)
-        assertEquals(1.2260465117422445, unit.dispersionFactor(57, 50.0), 0.0000000000001)
-        assertEquals(4.384923959784047, unit.dispersionFactor(97, 50.0), 0.0000000000001)
-
-    }
-
-    @Test
-    fun dispersion_factor_calcs_at_70_yards_does_metric_conversion() {
-        //70y == 64.008m
-        var unit = HandicapCalculator()
-
-        assertEquals(1.00783160883481, unit.dispersionFactorYards(0, 70), 0.0000000000001)
-        assertEquals(1.03469717341738, unit.dispersionFactorYards(22, 70), 0.0000000000001)
-        assertEquals(1.34621233577242, unit.dispersionFactorYards(56, 70), 0.0000000000001)
-        assertEquals(3.01057722079535, unit.dispersionFactorYards(82, 70), 0.0000000000001)
+        assertBigDecimalEquals(BigDecimal(1.0062640842793422), unit.dispersionFactor(4, BigDecimal(50.0)))
+        assertBigDecimalEquals(BigDecimal(1.2260465117422445), unit.dispersionFactor(57, BigDecimal(50.0)))
+        assertBigDecimalEquals(BigDecimal(4.384923959784047), unit.dispersionFactor(97, BigDecimal(50.0)))
 
     }
 
@@ -174,6 +162,29 @@ class HandicapCalculatorTest {
         assertBigDecimalEquals(BigDecimal.valueOf(0.8217381029), unit.angularDeviation())
     }
 
+    @Test
+    fun get_group_radius() {
+        var unit = HandicapCalculator()
+        unit.setHandicap(8)
+        unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
+        assertBigDecimalEquals(BigDecimal.valueOf(7.4476726237), unit.groupRadius())
+        unit.setHandicap(45)
+        unit.setTargetDistance(Dimension(40.0f, Dimension.Unit.METER))
+        assertBigDecimalEquals(BigDecimal.valueOf(16.4967128591), unit.groupRadius())
+        unit.setHandicap(82)
+        unit.setTargetDistance(Dimension(20.0f, Dimension.Unit.METER))
+        assertBigDecimalEquals(BigDecimal.valueOf(34.3146495334), unit.groupRadius())
+    }
+
+    @Test
+    fun get_group_radius_imperial() {
+        var unit = HandicapCalculator()
+        unit.setHandicap(55)
+        unit.setTargetDistance(Dimension(60.0f, Dimension.Unit.YARDS))
+        assertBigDecimalEquals(BigDecimal.valueOf(37.4808083757), unit.groupRadius())
+        // TODO - check this calc - may just be imperial rounding error
+//        assertBigDecimalEquals(BigDecimal.valueOf(37.48065477), unit.groupRadius())
+    }
 }
 
 

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -288,8 +288,8 @@ class HandicapCalculatorTest {
         assertEquals(101, handicapList.size)
 
         assertEquals(324, handicapList.get(18))
-        assertEquals(233, handicapList.get(42))
-        assertEquals(35, handicapList.get(68))
+        assertEquals(232, handicapList.get(42))
+        assertEquals(34, handicapList.get(68))
     }
 
     @Test
@@ -374,7 +374,7 @@ class HandicapCalculatorTest {
 
     @Test
     fun handicap_calculator_construction_with_different_arrow_radius() {
-
+        // TODO: set arrow radius as dimension not literal
         var distance = Dimension(70f, Dimension.Unit.METER)
         var diameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var target = Target(WAFull.ID, 0,  diameter)
@@ -388,13 +388,14 @@ class HandicapCalculatorTest {
 
         //23xx arrows
         unit.setArrowRadius(BigDecimal("0.456"))
-        assertThat(unit.getHandicap(647), equalTo(21))
-        assertThat(unit.getHandicap(648), equalTo(20))
+        assertThat(unit.getHandicap(648), equalTo(18))
+        assertThat(unit.getHandicap(647), equalTo(19))
 
         //27xx arrows
         unit.setArrowRadius(BigDecimal("0.53578"))
-        assertThat(unit.getHandicap(647), equalTo(21))
-        assertThat(unit.getHandicap(649), equalTo(20))
+        assertThat(unit.getHandicap(640), equalTo(20))
+        assertThat(unit.getHandicap(636), equalTo(21))
+        assertThat(unit.getHandicap(632), equalTo(22))
 
     }
 }

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -27,7 +27,13 @@ import de.dreier.mytargets.shared.R
 import de.dreier.mytargets.shared.SharedApplicationInstance
 import de.dreier.mytargets.shared.models.Dimension
 import de.dreier.mytargets.shared.models.HandicapCalculator
+import de.dreier.mytargets.shared.models.Score
+import de.dreier.mytargets.shared.models.Target
+import de.dreier.mytargets.shared.models.db.Round
 import de.dreier.mytargets.shared.targets.scoringstyle.ScoringStyle
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.notNullValue
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -39,16 +45,6 @@ import java.math.RoundingMode
 @RunWith(AndroidJUnit4::class)
 class HandicapCalculatorTest {
     private lateinit var context: Context
-
-    //    @Test
-//    fun handicapTestWithNoArrowSet() {
-//        val distance = 70
-//        val score = 252
-//        val unit = HandicapCalculator()
-//        val handicap = unit.setDistance(distance).setScore(score).setTargetSize(122).setZones(10).setInnerRing(false).calculate();
-//        assertEqual()
-//    }
-
 
     @Before
     @Throws(Exception::class)
@@ -64,16 +60,16 @@ class HandicapCalculatorTest {
     fun set_distance_in_metres() {
         val unit = HandicapCalculator()
         unit.setTargetDistance(Dimension(18f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal.valueOf(18), unit.metricDistance(), scale = 0)
+        assertBigDecimalEquals(BigDecimal.valueOf(18), unit.metricDistance, scale = 0)
     }
 
     @Test
     fun test_set_distance_in_yards_calculates_metres() {
         val unit = HandicapCalculator()
         unit.setTargetDistance(Dimension(15f, Dimension.Unit.YARDS))
-        assertEquals(Dimension.Unit.YARDS, unit.targetDistance().unit)
-        assertEquals(15f, unit.targetDistance().value)
-        assertBigDecimalEquals(BigDecimal.valueOf(13.716), unit.metricDistance(), scale = 3)
+        assertEquals(Dimension.Unit.YARDS, unit.targetDistance.unit)
+        assertEquals(15f, unit.targetDistance.value)
+        assertBigDecimalEquals(BigDecimal.valueOf(13.716), unit.metricDistance, scale = 3)
     }
 
     @Test
@@ -316,6 +312,35 @@ class HandicapCalculatorTest {
         assertEquals(10, unit.getHandicap(679))
         assertEquals(9, unit.getHandicap(680))
 
+    }
+
+    @Test
+    fun handicap_calculator_construction_from_round() {
+//        unit.setTargetModel(WAFull())
+//        unit.setScoringStyleIndex(1)
+//        unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
+//        unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
+
+        var distance = Dimension(70f, Dimension.Unit.METER)
+        var diameter = Dimension(122f, Dimension.Unit.CENTIMETER)
+        var target = Target(WAFull.ID, 2,  diameter)
+        var score = Score(222)
+        var round = Round(0, 0, 0, 6, 6, distance, "test", target, score )
+
+        var unit = HandicapCalculator(round)
+
+        assertThat(unit.targetModel, notNullValue())
+        assertThat(unit.scoringStyleIndex, equalTo(2))
+        assertThat(unit.arrowCount, equalTo(36))
+        assertThat(unit.targetSize.value, equalTo(122f))
+        assertThat(unit.targetSize.unit, equalTo(Dimension.Unit.CENTIMETER))
+        assertThat(unit.targetDistance.value, equalTo(70f))
+        assertThat(unit.targetDistance.unit, equalTo(Dimension.Unit.METER))
+        assertThat(unit.metricDistance, equalTo(BigDecimal("70.0")))
+
+        assertThat(unit.getHandicap(round.score.totalPoints), equalTo(44))
+//        private var arrowRadius = BigDecimal("0.357")
+//          TODO: the same with imperial
     }
 }
 

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2018 Florian Dreier
+ * MyTargets Project Copyright (C) 2018 Florian Dreier
  *
- * This file is part of MyTargets.
+ * This file is (c) 2021 Jez McKinley
  *
  * Calculations used in this file are courtesy of Jack Atkinson - see:
  * https://www.jackatkinson.net/post/archery_handicap/
@@ -149,7 +149,7 @@ class HandicapCalculatorTest {
         var unit = WAFull()
 
         // Should be compound target 60cm
-        var zoneMap = unit.getZoneSizeMapFromProperties(2, 1)
+        var zoneMap = unit.getZoneSizeMapFromIndices(2, 1)
         assertEquals(10, zoneMap.size)
         assertEquals("1.500", zoneMap.get(10).toString())
         assertEquals("6.00", zoneMap.get(9).toString())
@@ -195,17 +195,17 @@ class HandicapCalculatorTest {
         unit.setScoringStyleIndex(1)
 
        // 122cm, 70m
-        unit.setTargetSizeIndex(4)
+        unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
         assertBigDecimalEquals(BigDecimal("8.9900035590"), unit.averageArrowScoreForHandicap(18))
 
         // 80cm, 60m
-        unit.setTargetSizeIndex(2)
+        unit.setTargetSize(Dimension(80f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(60.0f, Dimension.Unit.METER))
         assertBigDecimalEquals(BigDecimal("4.8349706596"), unit.averageArrowScoreForHandicap(45))
 
         // 40cm, 40m
-        unit.setTargetSizeIndex(0)
+        unit.setTargetSize(Dimension(40f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(40.0f, Dimension.Unit.METER))
         assertBigDecimalEquals(BigDecimal("0.1524555998"), unit.averageArrowScoreForHandicap(82))
     }
@@ -219,17 +219,17 @@ class HandicapCalculatorTest {
         unit.setScoringStyleIndex(2)
 
         // 122cm, 70m
-        unit.setTargetSizeIndex(4)
+        unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
         assertBigDecimalEquals(BigDecimal("6.5866551614"), unit.averageArrowScoreForHandicap(41))
 
         // 80cm, 60m
-        unit.setTargetSizeIndex(2)
+        unit.setTargetSize(Dimension(80f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(60.0f, Dimension.Unit.METER))
         assertBigDecimalEquals(BigDecimal("8.8028056795"), unit.averageArrowScoreForHandicap(11))
 
         // 40cm, 40m
-        unit.setTargetSizeIndex(0)
+        unit.setTargetSize(Dimension(40f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(40.0f, Dimension.Unit.METER))
         assertBigDecimalEquals(BigDecimal("0.9617396800"), unit.averageArrowScoreForHandicap(65))
     }
@@ -243,17 +243,17 @@ class HandicapCalculatorTest {
         unit.setScoringStyleIndex(5)
 
         // 122cm, 70m
-        unit.setTargetSizeIndex(4)
+        unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
         assertBigDecimalEquals(BigDecimal("6.8828612028"), unit.averageArrowScoreForHandicap(36))
 
         // 122cm, 80y (73.152m)
-        unit.setTargetSizeIndex(4)
+        unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(80.0f, Dimension.Unit.YARDS))
         assertBigDecimalEquals(BigDecimal("6.7122001518"), unit.averageArrowScoreForHandicap(36))
 
         // 60cm, 18m
-        unit.setTargetSizeIndex(1)
+        unit.setTargetSize(Dimension(60f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(18.0f, Dimension.Unit.METER))
         assertBigDecimalEquals(BigDecimal("8.9152743398"), unit.averageArrowScoreForHandicap(26))
 
@@ -268,12 +268,12 @@ class HandicapCalculatorTest {
         unit.setArrowRadius(BigDecimal("0.4564"))
 
         // 122cm, 70m
-        unit.setTargetSizeIndex(4)
+        unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
         assertBigDecimalEquals(BigDecimal("4.9782780054"), unit.averageArrowScoreForHandicap(49))
 
         // 60cm, 18m
-        unit.setTargetSizeIndex(1)
+        unit.setTargetSize(Dimension(60f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(18.0f, Dimension.Unit.METER))
         assertBigDecimalEquals(BigDecimal("9.5680222762"), unit.averageArrowScoreForHandicap(26))
     }
@@ -286,7 +286,7 @@ class HandicapCalculatorTest {
 
         // 122cm, 70m, WA Metric Recurve
         unit.setScoringStyleIndex(1)
-        unit.setTargetSizeIndex(4)
+        unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
 
         unit.setArrowCount(36)
@@ -306,7 +306,7 @@ class HandicapCalculatorTest {
 
         // 122cm, 70m, WA Metric Recurve
         unit.setScoringStyleIndex(1)
-        unit.setTargetSizeIndex(4)
+        unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
 
         unit.setArrowCount(72)

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -28,7 +28,7 @@ import de.dreier.mytargets.shared.SharedApplicationInstance
 import de.dreier.mytargets.shared.models.Dimension
 import de.dreier.mytargets.shared.models.HandicapCalculator
 import de.dreier.mytargets.shared.targets.scoringstyle.ScoringStyle
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -56,28 +56,23 @@ class HandicapCalculatorTest {
         SharedApplicationInstance.context = InstrumentationRegistry.getInstrumentation().targetContext
     }
 
+    fun assertBigDecimalEquals(expected: BigDecimal, actual: BigDecimal, scale: Int=10, roundingMode: RoundingMode=RoundingMode.HALF_UP) {
+        assertEquals(expected.setScale(scale, roundingMode), actual.setScale(scale, roundingMode))
+    }
+
+    @Test
+    fun set_distance_in_metres() {
+        val unit = HandicapCalculator()
+        unit.setTargetDistance(Dimension(18f, Dimension.Unit.METER))
+        assertBigDecimalEquals(BigDecimal.valueOf(18), unit.metricDistance(), scale = 0)
+    }
 
     @Test
     fun test_set_distance_in_yards_calculates_metres() {
         val unit = HandicapCalculator()
-        unit.setTargetDistanceYards(15)
-        assertEquals(15, unit.targetDistanceYards())
-        assertEquals(13.716, unit.targetDistanceMetres())
-    }
-
-    @Test
-    fun set_distance_in_yards_also_sets_metric_false() {
-        val unit = HandicapCalculator()
-        unit.setTargetDistanceYards(33)
-        assertFalse(unit.isMetric())
-    }
-
-    @Test
-    fun set_distance_in_metres_does_not_set_yardage() {
-        val unit = HandicapCalculator()
-        unit.setTargetDistanceMetres(18)
-        assertTrue(unit.isMetric())
-        assertEquals(0, unit.targetDistanceYards())
+        unit.setTargetDistance(Dimension(15f, Dimension.Unit.YARDS))
+        assertBigDecimalEquals(BigDecimal.valueOf(13.716), unit.metricDistance(), scale = 3)
+        assertEquals(Dimension.Unit.YARDS, unit.targetDistance().unit)
     }
 
     @Test
@@ -172,11 +167,11 @@ class HandicapCalculatorTest {
     fun get_angular_deviation_for_handicap() {
         var unit = HandicapCalculator()
         unit.setHandicap(8)
-        assertEquals("0.0599945120", unit.angularDeviation().setScale(10, RoundingMode.HALF_UP).toString())
+        assertBigDecimalEquals(BigDecimal.valueOf(0.0599945120), unit.angularDeviation())
         unit.setHandicap(45)
-        assertEquals("0.2220355297", unit.angularDeviation().setScale(10, RoundingMode.HALF_UP).toString())
+        assertBigDecimalEquals(BigDecimal.valueOf(0.2220355297), unit.angularDeviation())
         unit.setHandicap(82)
-        assertEquals("0.8217381029", unit.angularDeviation().setScale(10, RoundingMode.HALF_UP).toString())
+        assertBigDecimalEquals(BigDecimal.valueOf(0.8217381029), unit.angularDeviation())
     }
 
 }

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -30,6 +30,7 @@ import de.dreier.mytargets.shared.models.HandicapCalculator
 import de.dreier.mytargets.shared.targets.scoringstyle.ScoringStyle
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.math.BigDecimal
@@ -127,10 +128,14 @@ class HandicapCalculatorTest {
 
         var zoneMap = unit.getZoneSizeMap(scoringStyle, targetSize)
         assertEquals(10, zoneMap.size)
+
         assertEquals(BigDecimal.valueOf(6.1), zoneMap.get(10)?.stripTrailingZeros())
         assertEquals(BigDecimal.valueOf(12.2), zoneMap.get(9)?.stripTrailingZeros())
         assertEquals(BigDecimal.valueOf(36.6), zoneMap.get(5)?.stripTrailingZeros())
         assertEquals(BigDecimal.valueOf(61), zoneMap.get(1)?.stripTrailingZeros())
+
+        assertEquals(zoneMap.entries.first().value, zoneMap.get(10))
+        assertEquals(zoneMap.entries.last().value, zoneMap.get(1))
     }
 
     @Test
@@ -164,11 +169,11 @@ class HandicapCalculatorTest {
     fun get_angular_deviation_for_handicap() {
         var unit = HandicapCalculator()
         unit.setHandicap(8)
-        assertBigDecimalEquals(BigDecimal.valueOf(0.0599945120), unit.angularDeviation())
+        assertBigDecimalEquals(BigDecimal("0.0599945120"), unit.angularDeviation())
         unit.setHandicap(45)
-        assertBigDecimalEquals(BigDecimal.valueOf(0.2220355297), unit.angularDeviation())
+        assertBigDecimalEquals(BigDecimal("0.2220355297"), unit.angularDeviation())
         unit.setHandicap(82)
-        assertBigDecimalEquals(BigDecimal.valueOf(0.8217381029), unit.angularDeviation())
+        assertBigDecimalEquals(BigDecimal("0.8217381029"), unit.angularDeviation())
     }
 
     @Test
@@ -176,13 +181,13 @@ class HandicapCalculatorTest {
         var unit = HandicapCalculator()
         unit.setHandicap(8)
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal.valueOf(7.4476726237), unit.groupRadius())
+        assertBigDecimalEquals(BigDecimal("7.4476726237"), unit.groupRadius())
         unit.setHandicap(45)
         unit.setTargetDistance(Dimension(40.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal.valueOf(16.4967128591), unit.groupRadius())
+        assertBigDecimalEquals(BigDecimal("16.4967128591"), unit.groupRadius())
         unit.setHandicap(82)
         unit.setTargetDistance(Dimension(20.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal.valueOf(34.3146495334), unit.groupRadius())
+        assertBigDecimalEquals(BigDecimal("34.3146495334"), unit.groupRadius())
     }
 
     @Test
@@ -190,11 +195,98 @@ class HandicapCalculatorTest {
         var unit = HandicapCalculator()
         unit.setHandicap(55)
         unit.setTargetDistance(Dimension(60.0f, Dimension.Unit.YARDS))
-        assertBigDecimalEquals(BigDecimal.valueOf(37.4808083757), unit.groupRadius())
+        assertBigDecimalEquals(BigDecimal("37.4808083757"), unit.groupRadius())
         // TODO - check this calc - may just be imperial rounding error
 //        assertBigDecimalEquals(BigDecimal.valueOf(37.48065477), unit.groupRadius())
     }
     // https://dzone.com/articles/never-use-float-and-double-for-monetary-calculatio
+
+    @Test
+    fun get_average_arrow_for_handicap_10_zone_recurve() {
+        // should we use Target instead of TargetModelBase as this has size and scorestyle bound?
+        // Should be 122 target 70m
+        var unit = HandicapCalculator()
+        unit.setTargetModel(WAFull())
+        unit.setScoringStyleIndex(1)
+
+       // 122cm, 70m
+        unit.setHandicap(18)
+        unit.setTargetSizeIndex(4)
+        unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
+        assertBigDecimalEquals(BigDecimal("8.9900035590"), unit.averageArrowScore())
+
+        // 80cm, 60m
+        unit.setHandicap(45)
+        unit.setTargetSizeIndex(2)
+        unit.setTargetDistance(Dimension(60.0f, Dimension.Unit.METER))
+        assertBigDecimalEquals(BigDecimal("4.8349706596"), unit.averageArrowScore())
+
+        // 40cm, 40m
+        unit.setHandicap(82)
+        unit.setTargetSizeIndex(0)
+        unit.setTargetDistance(Dimension(40.0f, Dimension.Unit.METER))
+        assertBigDecimalEquals(BigDecimal("0.1524555998"), unit.averageArrowScore())
+    }
+
+    @Test
+    fun get_average_arrow_for_handicap_10_zone_compound() {
+        // should we use Target instead of TargetModelBase as this has size and scorestyle bound?
+        // Should be 122 target 70m
+        var unit = HandicapCalculator()
+        unit.setTargetModel(WAFull())
+        unit.setScoringStyleIndex(2)
+
+        // 122cm, 70m
+        unit.setHandicap(41)
+        unit.setTargetSizeIndex(4)
+        unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
+        assertBigDecimalEquals(BigDecimal("6.5866551614"), unit.averageArrowScore())
+
+        // 80cm, 60m
+        unit.setHandicap(11)
+        unit.setTargetSizeIndex(2)
+        unit.setTargetDistance(Dimension(60.0f, Dimension.Unit.METER))
+        assertBigDecimalEquals(BigDecimal("8.8028056795"), unit.averageArrowScore())
+
+        // 40cm, 40m
+        unit.setHandicap(65)
+        unit.setTargetSizeIndex(0)
+        unit.setTargetDistance(Dimension(40.0f, Dimension.Unit.METER))
+        assertBigDecimalEquals(BigDecimal("0.9617396800"), unit.averageArrowScore())
+    }
+
+    @Ignore
+    @Test
+    fun get_average_arrow_for_handicap_5_zone_imperial() {
+        // should we use Target instead of TargetModelBase as this has size and scorestyle bound?
+        // Should be 122 target 70m
+        var unit = HandicapCalculator()
+        unit.setTargetModel(WAFull())
+        unit.setScoringStyleIndex(5)
+
+        // 122cm, 70m
+        unit.setHandicap(36)
+        unit.setTargetSizeIndex(4)
+        unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
+        assertBigDecimalEquals(BigDecimal("6.88"), unit.averageArrowScore())
+
+        // 122cm, 80y (73.152m)
+        unit.setHandicap(36)
+        unit.setTargetSizeIndex(4)
+        unit.setTargetDistance(Dimension(80.0f, Dimension.Unit.YARDS))
+        assertBigDecimalEquals(BigDecimal("6.71"), unit.averageArrowScore())
+
+        // 60cm, 18m
+        unit.setHandicap(26)
+        unit.setTargetSizeIndex(1)
+        unit.setTargetDistance(Dimension(18.0f, Dimension.Unit.METER))
+        assertBigDecimalEquals(BigDecimal("8.92"), unit.averageArrowScore())
+
+    }
+
+    fun test_with_different_arrow_diameter() {
+        assertEquals(1,1)
+    }
 }
 
 

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -30,7 +30,6 @@ import de.dreier.mytargets.shared.models.HandicapCalculator
 import de.dreier.mytargets.shared.targets.scoringstyle.ScoringStyle
 import org.junit.Assert.assertEquals
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.math.BigDecimal
@@ -283,26 +282,25 @@ class HandicapCalculatorTest {
 
     }
 
-    @Ignore
     @Test
     fun test_with_different_arrow_diameter() {
 
         var unit = HandicapCalculator()
         unit.setTargetModel(WAFull())
-        unit.setScoringStyleIndex(2)
-        unit.setArrowRadius(BigDecimal("4.5641"))
+        unit.setScoringStyleIndex(1)
+        unit.setArrowRadius(BigDecimal("0.4564"))
 
-        // 122cm, 80y (73.152m)
-        unit.setHandicap(36)
+        // 122cm, 70m
+        unit.setHandicap(49)
         unit.setTargetSizeIndex(4)
-        unit.setTargetDistance(Dimension(80.0f, Dimension.Unit.YARDS))
-        assertBigDecimalEquals(BigDecimal("6.7122001518"), unit.averageArrowScore())
+        unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
+        assertBigDecimalEquals(BigDecimal("4.9782780054"), unit.averageArrowScore())
 
         // 60cm, 18m
         unit.setHandicap(26)
         unit.setTargetSizeIndex(1)
         unit.setTargetDistance(Dimension(18.0f, Dimension.Unit.METER))
-        assertBigDecimalEquals(BigDecimal("8.9152743398"), unit.averageArrowScore())
+        assertBigDecimalEquals(BigDecimal("9.5680222762"), unit.averageArrowScore())
     }
 }
 

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/MultiRoundHandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/MultiRoundHandicapCalculatorTest.kt
@@ -1,0 +1,148 @@
+/*
+ * MyTargets Project Copyright (C) 2018 Florian Dreier
+ *
+ * This file is (c) 2021 Jez McKinley - Canford Magna Bowmen
+ *
+ * Calculations used in this file are courtesy of Jack Atkinson - see:
+ * https://www.jackatkinson.net/post/archery_handicap/
+ * derived from David Lane's Handicap Calcs for Toxophilus 1979
+ *
+ * MyTargets is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * MyTargets is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+package de.dreier.mytargets.shared.targets.models
+
+import android.content.Context
+import androidx.test.filters.SmallTest
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
+import de.dreier.mytargets.shared.SharedApplicationInstance
+import de.dreier.mytargets.shared.models.Dimension
+import de.dreier.mytargets.shared.models.MultiRoundHandicapCalculator
+import de.dreier.mytargets.shared.models.Score
+import de.dreier.mytargets.shared.models.Target
+import de.dreier.mytargets.shared.models.db.Round
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@SmallTest
+@RunWith(AndroidJUnit4::class)
+class MultiRoundHandicapCalculatorTest {
+    private lateinit var context: Context
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        SharedApplicationInstance.context = InstrumentationRegistry.getInstrumentation().targetContext
+    }
+
+    @Test
+    fun handicap_from_single_metric_wa_70() {
+        //        WA, R.string.wa_70,
+        //        Dimension.Unit.METER, CENTIMETER,
+        // first params here are targetface, scoringstyle and shotsperend, the tuples are distance, diameter and ends
+        //        WAFull.ID, 0, 6, 70, 122, 12
+        var longDistance = Dimension(70f, Dimension.Unit.METER)
+        var longDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
+        var longTarget = Target(WAFull.ID, 0, longDiameter)
+        var longScore = Score(685)
+        var longRound = Round(0, 0, 0, 6, 12, longDistance, "70m", longTarget, longScore)
+
+        var rounds = ArrayList<Round>()
+        rounds.add(longRound)
+        var unit = MultiRoundHandicapCalculator(rounds)
+
+        assertThat(unit.getHandicap(), equalTo(7))
+
+    }
+
+    @Test
+    fun handicap_from_two_sub_rounds_metric_wa_combined_25_18() {
+        //        WA, R.string.wa_combined,
+        //        Dimension.Unit.METER, CENTIMETER,
+        // first params here are targetface, scoringstyle and shotsperend, the tuples are distance, diameter and ends
+        //        WAFull.ID, 0, 3, 25, 60, 20, 18, 40, 20
+        var longDistance = Dimension(25f, Dimension.Unit.METER)
+        var longDiameter = Dimension(60f, Dimension.Unit.CENTIMETER)
+        var longTarget = Target(WAFull.ID, 0, longDiameter)
+        var longScore = Score(580)
+        var longRound = Round(0, 0, 0, 3, 20, longDistance, "100y", longTarget, longScore)
+
+        var shortDistance = Dimension(18f, Dimension.Unit.METER)
+        var shortDiameter = Dimension(40f, Dimension.Unit.CENTIMETER)
+        var shortTarget = Target(WAFull.ID, 0, shortDiameter)
+        var shortScore = Score(601)
+        var shortRound = Round(0, 0, 0, 3, 20, shortDistance, "60y", shortTarget, shortScore)
+
+        var rounds = ArrayList<Round>()
+        rounds.add(longRound)
+        rounds.add(shortRound)
+        var unit = MultiRoundHandicapCalculator(rounds)
+
+        assertThat(unit.getHandicap(), equalTo(6))
+
+        assertThat(unit.getHandicapForScore(1181), equalTo(6))
+        assertThat(unit.getHandicapForScore(976), equalTo(40))
+        assertThat(unit.getHandicapForScore(215), equalTo(80))
+
+        //David Lane's calculations only rounds the total score after the individual rounds are added together
+        // Testing a few boundaries
+        assertThat(unit.getHandicapForScore(995), equalTo(38))
+        assertThat(unit.getHandicapForScore(994), equalTo(39))
+        assertThat(unit.getHandicapForScore(985), equalTo(39))
+    }
+
+    @Test
+    fun handicap_from_three_sub_rounds_imperial_york() {
+        // TODO: Find out if there are any hybrid rounds in existence that use different scoring per distance
+        // ARCHERY_GB, R.string.york,
+        // YARDS, CENTIMETER,
+        // first params here are targetface, scoringstyle and shotsperend, the tuples are distance, diameter and ends
+        // WAFull.ID, 5, 6, 100, 122, 12, 80, 122, 8, 60, 122, 4
+        var longDistance = Dimension(100f, Dimension.Unit.YARDS)
+        var longDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
+        var longTarget = Target(WAFull.ID, 5, longDiameter)
+        var longScore = Score(504)
+        var longRound = Round(0, 0, 0, 6, 12, longDistance, "100y", longTarget, longScore)
+
+        var midDistance = Dimension(80f, Dimension.Unit.YARDS)
+        var midDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
+        var midTarget = Target(WAFull.ID, 5, midDiameter)
+        var midScore = Score(336)
+        var midRound = Round(0, 0, 0, 6, 8, midDistance, "80y", midTarget, midScore)
+
+        var shortDistance = Dimension(60f, Dimension.Unit.YARDS)
+        var shortDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
+        var shortTarget = Target(WAFull.ID, 5, shortDiameter)
+        var shortScore = Score(168)
+        var shortRound = Round(0, 0, 0, 6, 4, shortDistance, "60y", shortTarget, shortScore)
+
+        var rounds = ArrayList<Round>()
+        rounds.add(longRound)
+        rounds.add(midRound)
+        rounds.add(shortRound)
+        var unit = MultiRoundHandicapCalculator(rounds)
+
+        // Score 1008
+        assertThat(unit.getHandicap(), equalTo(32))
+
+        assertThat(unit.getHandicapForScore(1015), equalTo(31))
+        assertThat(unit.getHandicapForScore(1014), equalTo(32))
+        assertThat(unit.getHandicapForScore(995), equalTo(33))
+
+        //David Lane's calculations only rounds the total score after the individual rounds are added together
+        //If you round the scores of rounds before adding them together, this will calc to a 33
+        assertThat(unit.getHandicapForScore(996), equalTo(32))
+    }
+}
+

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/MultiRoundHandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/MultiRoundHandicapCalculatorTest.kt
@@ -34,6 +34,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.math.BigDecimal
 
 @SmallTest
 @RunWith(AndroidJUnit4::class)
@@ -54,10 +55,12 @@ class MultiRoundHandicapCalculatorTest {
         var longScore = Score(685, 720)
         var longRound = Round(0, 0, 0, 6, 12, longDistance, "70m", longTarget, longScore)
 
+        var arrowDiameter = Dimension(0.281f, Dimension.Unit.INCH)
         var rounds = ArrayList<Round>()
         rounds.add(longRound)
-        var unit = MultiRoundHandicapCalculator(rounds)
+        var unit = MultiRoundHandicapCalculator(rounds, arrowDiameter)
 
+        assertThat(unit.arrowRadius, equalTo(BigDecimal("0.357")))
         assertThat(unit.totalScore, equalTo(720))
         assertThat(unit.reachedScore, equalTo(685))
         assertThat(unit.rounds.size, equalTo(1))
@@ -66,6 +69,7 @@ class MultiRoundHandicapCalculatorTest {
 
     @Test
     fun construction_multi_round() {
+        var arrowDiameter = Dimension(0.714f, Dimension.Unit.CENTIMETER)
         var longDistance = Dimension(100f, Dimension.Unit.YARDS)
         var longDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var longTarget = Target(WAFull.ID, 5, longDiameter)
@@ -88,8 +92,9 @@ class MultiRoundHandicapCalculatorTest {
         rounds.add(longRound)
         rounds.add(midRound)
         rounds.add(shortRound)
-        var unit = MultiRoundHandicapCalculator(rounds)
+        var unit = MultiRoundHandicapCalculator(rounds, arrowDiameter)
 
+        assertThat(unit.arrowRadius, equalTo(BigDecimal("0.357")))
         assertThat(unit.totalScore, equalTo(1296))
         assertThat(unit.reachedScore, equalTo(1008))
         assertThat(unit.rounds.size, equalTo(3))
@@ -108,9 +113,10 @@ class MultiRoundHandicapCalculatorTest {
         var longScore = Score(685, 720)
         var longRound = Round(0, 0, 0, 6, 12, longDistance, "70m", longTarget, longScore)
 
+        var arrowDiameter = Dimension(0.714f, Dimension.Unit.CENTIMETER)
         var rounds = ArrayList<Round>()
         rounds.add(longRound)
-        var unit = MultiRoundHandicapCalculator(rounds)
+        var unit = MultiRoundHandicapCalculator(rounds, arrowDiameter)
 
         assertThat(unit.getHandicap(), equalTo(7))
 
@@ -134,10 +140,11 @@ class MultiRoundHandicapCalculatorTest {
         var shortScore = Score(591, 600)
         var shortRound = Round(0, 0, 0, 3, 20, shortDistance, "60y", shortTarget, shortScore)
 
+        var arrowDiameter = Dimension(0.714f, Dimension.Unit.CENTIMETER)
         var rounds = ArrayList<Round>()
         rounds.add(longRound)
         rounds.add(shortRound)
-        var unit = MultiRoundHandicapCalculator(rounds)
+        var unit = MultiRoundHandicapCalculator(rounds, arrowDiameter)
 
         assertThat(unit.getHandicap(), equalTo(6))
 
@@ -177,11 +184,12 @@ class MultiRoundHandicapCalculatorTest {
         var shortScore = Score(168, 216)
         var shortRound = Round(0, 0, 0, 6, 4, shortDistance, "60y", shortTarget, shortScore)
 
+        var arrowDiameter = Dimension(0.714f, Dimension.Unit.CENTIMETER)
         var rounds = ArrayList<Round>()
         rounds.add(longRound)
         rounds.add(midRound)
         rounds.add(shortRound)
-        var unit = MultiRoundHandicapCalculator(rounds)
+        var unit = MultiRoundHandicapCalculator(rounds, arrowDiameter)
 
         // Score 1008
         assertThat(unit.getHandicap(), equalTo(32))
@@ -194,5 +202,16 @@ class MultiRoundHandicapCalculatorTest {
         //If you round the scores of rounds before adding them together, this will calc to a 33
         assertThat(unit.getHandicapForScore(996), equalTo(32))
     }
+
+    @Test
+    fun dimensionToString() {
+        var unit = Dimension(22.5487f, Dimension.Unit.CENTIMETER)
+        assertThat(unit.formatString(), equalTo("22.5487 cm"))
+
+        unit = Dimension(22.54f, Dimension.Unit.INCH)
+        assertThat(unit.formatString(), equalTo("22.54 in"))
+    }
+
+
 }
 

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/MultiRoundHandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/MultiRoundHandicapCalculatorTest.kt
@@ -47,6 +47,56 @@ class MultiRoundHandicapCalculatorTest {
     }
 
     @Test
+    fun construction_single_round() {
+        var longDistance = Dimension(70f, Dimension.Unit.METER)
+        var longDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
+        var longTarget = Target(WAFull.ID, 0, longDiameter)
+        var longScore = Score(685, 720)
+        var longRound = Round(0, 0, 0, 6, 12, longDistance, "70m", longTarget, longScore)
+
+        var rounds = ArrayList<Round>()
+        rounds.add(longRound)
+        var unit = MultiRoundHandicapCalculator(rounds)
+
+        assertThat(unit.totalScore, equalTo(720))
+        assertThat(unit.reachedScore, equalTo(685))
+        assertThat(unit.rounds.size, equalTo(1))
+
+    }
+
+    @Test
+    fun construction_multi_round() {
+        var longDistance = Dimension(100f, Dimension.Unit.YARDS)
+        var longDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
+        var longTarget = Target(WAFull.ID, 5, longDiameter)
+        var longScore = Score(504, 648)
+        var longRound = Round(0, 0, 0, 6, 12, longDistance, "100y", longTarget, longScore)
+
+        var midDistance = Dimension(80f, Dimension.Unit.YARDS)
+        var midDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
+        var midTarget = Target(WAFull.ID, 5, midDiameter)
+        var midScore = Score(336, 432)
+        var midRound = Round(0, 0, 0, 6, 8, midDistance, "80y", midTarget, midScore)
+
+        var shortDistance = Dimension(60f, Dimension.Unit.YARDS)
+        var shortDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
+        var shortTarget = Target(WAFull.ID, 5, shortDiameter)
+        var shortScore = Score(168, 216)
+        var shortRound = Round(0, 0, 0, 6, 4, shortDistance, "60y", shortTarget, shortScore)
+
+        var rounds = ArrayList<Round>()
+        rounds.add(longRound)
+        rounds.add(midRound)
+        rounds.add(shortRound)
+        var unit = MultiRoundHandicapCalculator(rounds)
+
+        assertThat(unit.totalScore, equalTo(1296))
+        assertThat(unit.reachedScore, equalTo(1008))
+        assertThat(unit.rounds.size, equalTo(3))
+
+    }
+
+    @Test
     fun handicap_from_single_metric_wa_70() {
         //        WA, R.string.wa_70,
         //        Dimension.Unit.METER, CENTIMETER,
@@ -55,7 +105,7 @@ class MultiRoundHandicapCalculatorTest {
         var longDistance = Dimension(70f, Dimension.Unit.METER)
         var longDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var longTarget = Target(WAFull.ID, 0, longDiameter)
-        var longScore = Score(685)
+        var longScore = Score(685, 720)
         var longRound = Round(0, 0, 0, 6, 12, longDistance, "70m", longTarget, longScore)
 
         var rounds = ArrayList<Round>()
@@ -75,13 +125,13 @@ class MultiRoundHandicapCalculatorTest {
         var longDistance = Dimension(25f, Dimension.Unit.METER)
         var longDiameter = Dimension(60f, Dimension.Unit.CENTIMETER)
         var longTarget = Target(WAFull.ID, 0, longDiameter)
-        var longScore = Score(580)
+        var longScore = Score(590, 600)
         var longRound = Round(0, 0, 0, 3, 20, longDistance, "100y", longTarget, longScore)
 
         var shortDistance = Dimension(18f, Dimension.Unit.METER)
         var shortDiameter = Dimension(40f, Dimension.Unit.CENTIMETER)
         var shortTarget = Target(WAFull.ID, 0, shortDiameter)
-        var shortScore = Score(601)
+        var shortScore = Score(591, 600)
         var shortRound = Round(0, 0, 0, 3, 20, shortDistance, "60y", shortTarget, shortScore)
 
         var rounds = ArrayList<Round>()
@@ -112,19 +162,19 @@ class MultiRoundHandicapCalculatorTest {
         var longDistance = Dimension(100f, Dimension.Unit.YARDS)
         var longDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var longTarget = Target(WAFull.ID, 5, longDiameter)
-        var longScore = Score(504)
+        var longScore = Score(504, 648)
         var longRound = Round(0, 0, 0, 6, 12, longDistance, "100y", longTarget, longScore)
 
         var midDistance = Dimension(80f, Dimension.Unit.YARDS)
         var midDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var midTarget = Target(WAFull.ID, 5, midDiameter)
-        var midScore = Score(336)
+        var midScore = Score(336, 432)
         var midRound = Round(0, 0, 0, 6, 8, midDistance, "80y", midTarget, midScore)
 
         var shortDistance = Dimension(60f, Dimension.Unit.YARDS)
         var shortDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var shortTarget = Target(WAFull.ID, 5, shortDiameter)
-        var shortScore = Score(168)
+        var shortScore = Score(168, 216)
         var shortRound = Round(0, 0, 0, 6, 4, shortDistance, "60y", shortTarget, shortScore)
 
         var rounds = ArrayList<Round>()

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/TargetModelBaseTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/TargetModelBaseTest.kt
@@ -16,7 +16,7 @@
 package de.dreier.mytargets.shared.targets.models
 
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.runner.AndroidJUnit4
 import de.dreier.mytargets.shared.SharedApplicationInstance
 import de.dreier.mytargets.shared.models.Dimension
 import de.dreier.mytargets.shared.targets.TargetFactory
@@ -30,7 +30,7 @@ class TargetModelBaseTest {
 
     @Before
     fun setUp() {
-        SharedApplicationInstance.context = InstrumentationRegistry.getContext()
+        SharedApplicationInstance.context = InstrumentationRegistry.getInstrumentation().targetContext
     }
 
     @Test

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/TargetModelBaseTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/TargetModelBaseTest.kt
@@ -106,7 +106,7 @@ class TargetModelBaseTest {
 //        var targetSize = Dimension(122f, Dimension.Unit.CENTIMETER)
 //        var scoringStyle = ScoringStyle(R.string.recurve_style_x_1, true, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
 
-        var zoneMap = unit.getZoneSizeMapByIndex(0, 4)
+        var zoneMap = unit.getZoneSizeMapFromProperties(0, 4)
         Assert.assertEquals(10, zoneMap.size)
         Assert.assertEquals(6.6f, zoneMap.get(10))
         Assert.assertEquals(33f, zoneMap.get(5))

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/TargetModelBaseTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/TargetModelBaseTest.kt
@@ -106,7 +106,7 @@ class TargetModelBaseTest {
 //        var targetSize = Dimension(122f, Dimension.Unit.CENTIMETER)
 //        var scoringStyle = ScoringStyle(R.string.recurve_style_x_1, true, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
 
-        var zoneMap = unit.getZoneSizeMapFromProperties(0, 4)
+        var zoneMap = unit.getZoneSizeMapFromIndices(0, 4)
         Assert.assertEquals(10, zoneMap.size)
         Assert.assertEquals(6.6f, zoneMap.get(10))
         Assert.assertEquals(33f, zoneMap.get(5))

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/TargetModelBaseTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/TargetModelBaseTest.kt
@@ -99,4 +99,18 @@ class TargetModelBaseTest {
         Assert.assertEquals(realSize, Dimension(12f, Dimension.Unit.CENTIMETER))
     }
 
+
+    @Test
+    fun get_scoring_zone_sizes_simple_10_zone() {
+        val unit = TargetFactory.getTarget(WAFull.ID)
+//        var targetSize = Dimension(122f, Dimension.Unit.CENTIMETER)
+//        var scoringStyle = ScoringStyle(R.string.recurve_style_x_1, true, 10, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+
+        var zoneMap = unit.getZoneSizeMapByIndex(0, 4)
+        Assert.assertEquals(10, zoneMap.size)
+        Assert.assertEquals(6.6f, zoneMap.get(10))
+        Assert.assertEquals(33f, zoneMap.get(5))
+        Assert.assertEquals(66f, zoneMap.get(1))
+    }
+
 }

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/WAFullTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/WAFullTest.kt
@@ -15,11 +15,10 @@
 
 package de.dreier.mytargets.shared.targets.models
 
+import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry
-import android.support.test.filters.SmallTest
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.runner.AndroidJUnit4
 import de.dreier.mytargets.shared.SharedApplicationInstance
-
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -34,7 +33,7 @@ class WAFullTest {
     @Before
     @Throws(Exception::class)
     fun setUp() {
-        SharedApplicationInstance.context = InstrumentationRegistry.getContext()
+        SharedApplicationInstance.context = InstrumentationRegistry.getInstrumentation().targetContext
     }
 
     @Test

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/WAVertical3SpotTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/WAVertical3SpotTest.kt
@@ -15,9 +15,9 @@
 
 package de.dreier.mytargets.shared.targets.models
 
-import androidx.test.platform.app.InstrumentationRegistry
-import android.support.test.filters.SmallTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import androidx.test.platform.app.InstrumentationRegistry
 import de.dreier.mytargets.shared.SharedApplicationInstance
 
 import org.junit.Assert
@@ -34,7 +34,7 @@ class WAVertical3SpotTest {
     @Before
     @Throws(Exception::class)
     fun setUp() {
-        SharedApplicationInstance.context = InstrumentationRegistry.getContext()
+        SharedApplicationInstance.context = InstrumentationRegistry.getInstrumentation().targetContext
     }
 
     @Test

--- a/shared/src/main/java/de/dreier/mytargets/shared/SharedApplicationInstance.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/SharedApplicationInstance.kt
@@ -49,7 +49,6 @@ open class SharedApplicationInstance : Application() {
     companion object {
 
         lateinit var context: Context
-            internal set
 
         fun getStr(@StringRes string: Int): String {
             return context.getString(string)

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/Dimension.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/Dimension.kt
@@ -54,6 +54,10 @@ data class Dimension(val value: Float, val unit: Unit?) : IIdProvider, Comparabl
         return Dimension(newValue, unit)
     }
 
+    fun formatString(): String {
+        return this.value.toString() + " " + unit.toString()
+    }
+
     enum class Unit(
         internal val abbreviation: String,
         /* factor <units> = 1 meter */

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/Dimension.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/Dimension.kt
@@ -62,7 +62,7 @@ data class Dimension(val value: Float, val unit: Unit?) : IIdProvider, Comparabl
         CENTIMETER("cm", 100f),
         INCH("in", 39.3701f),
         METER("m", 1f),
-        YARDS("yd", 1.09361f),
+        YARDS("yd", 1.093613f),
         FEET("ft", 3.28084f),
         MILLIMETER("mm", 1000f);
 

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -15,8 +15,6 @@ class HandicapCalculator {
     private val inch2centimetre = 2.54
 
     private var handicap: Int = 0
-    private var handicapCoefficient: Double = 0.0
-    private var targetDistanceMetres: Double = 0.0
     private var arrowRadius = BigDecimal("0.357")
 
 
@@ -32,10 +30,6 @@ class HandicapCalculator {
         return handicap
     }
 
-    fun handicapCoefficient(): Double {
-        return handicapCoefficient
-    }
-
     fun yardsToMetres(yards: Int): Double {
         return yards * yards2metres
     }
@@ -45,28 +39,23 @@ class HandicapCalculator {
         this.metricDistance = BigDecimal.valueOf(distanceDimension.convertTo(Dimension.Unit.METER).value.toDouble())
     }
 
-    fun setHandicap(handicap: Int) {
-        this.handicap = handicap
-        this.handicapCoefficient = handicapCoefficient(handicap)
-    }
-
     fun handicapCoefficient(handicap: Int) :Double {
         //K=1.429*10^-6 * 1.07^(handicap+4.3)
         return 1.429*(10.00.pow(-6))*1.07.pow(handicap+4.3)
     }
 
-    fun dispersionFactor(): BigDecimal {
+    fun dispersionFactor(handicap: Int): BigDecimal {
         //F=1 + 1.429*10^-6 * 1.07^(handicap+4.3) * distance_in_metres^2
         return BigDecimal.valueOf(1 + 1.429 * (10.0.pow(-6)) * 1.07.pow(handicap+4.3) * metricDistance.toDouble().pow(2))
     }
 
-    fun angularDeviation(): BigDecimal {
+    fun angularDeviation(handicap: Int): BigDecimal {
        return  BigDecimal.valueOf((1.036.pow(handicap+12.9))*5*(10.0.pow(-4))*180/Math.PI)
     }
 
-    fun groupRadius(): BigDecimal {
+    fun groupRadius(handicap: Int): BigDecimal {
         //sigma=groupRadiusCm==100*distance_in_metres*(1.036^(handicap+12.9))*5*(10^-4)*Dispersion_Factor
-        return BigDecimal("0.05") * metricDistance * BigDecimal.valueOf(1.036.pow(handicap+12.9)) * dispersionFactor()
+        return BigDecimal("0.05") * metricDistance * BigDecimal.valueOf(1.036.pow(handicap+12.9)) * dispersionFactor(handicap)
     }
 
     fun setScoringStyleIndex(scoringStyleIndex: Int) {
@@ -81,9 +70,9 @@ class HandicapCalculator {
         this.targetModel = targetModel
     }
 
-    fun averageArrowScore(): BigDecimal {
+    fun averageArrowScoreForHandicap(handicap: Int): BigDecimal {
     //10-zone-Average_Arrow_Score=10 - (EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((7*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((8*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((9*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((10*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2))
-        val groupRadiusSquared = groupRadius().pow(2)
+        val groupRadiusSquared = groupRadius(handicap).pow(2)
         val zoneMap = targetModel.getZoneSizeMapFromProperties(scoringStyleIndex, targetSizeIndex)
         val bestArrowScore = BigDecimal(zoneMap.keys.max().toString())
 

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -82,18 +82,18 @@ class HandicapCalculator {
         return 1.429*(10.00.pow(-6))*1.07.pow(handicap+4.3)
     }
 
-    fun dispersionFactor(handicap: Int): BigDecimal {
-        //F=1 + 1.429*10^-6 * 1.07^(handicap+4.3) * distance_in_metres^2
-        return BigDecimal.valueOf(1 + 1.429 * (10.0.pow(-6)) * 1.07.pow(handicap+4.3) * metricDistance.toDouble().pow(2)).setScale(14, RoundingMode.HALF_UP)
+    fun angularDeviation(handicap: Int): BigDecimal {
+        return  BigDecimal.valueOf((1.036.pow(handicap+12.9))*5*(10.0.pow(-4))*180/Math.PI)
     }
 
-    fun angularDeviation(handicap: Int): BigDecimal {
-       return  BigDecimal.valueOf((1.036.pow(handicap+12.9))*5*(10.0.pow(-4))*180/Math.PI)
+    fun dispersionFactor(handicap: Int): BigDecimal {
+        //F=1 + 1.429*10^-6 * 1.07^(handicap+4.3) * distance_in_metres^2
+        return BigDecimal.valueOf(1 + 1.429 * (10.0.pow(-6)) * 1.07.pow(handicap+4.3) * metricDistance.toDouble().pow(2))
     }
 
     fun groupRadius(handicap: Int): BigDecimal {
         //sigma=groupRadiusCm==100*distance_in_metres*(1.036^(handicap+12.9))*5*(10^-4)*Dispersion_Factor
-        return BigDecimal("0.05") * metricDistance * BigDecimal.valueOf(1.036.pow(handicap+12.9)) * dispersionFactor(handicap).setScale(8, RoundingMode.HALF_UP)
+        return BigDecimal("0.05") * metricDistance * BigDecimal.valueOf(1.036.pow(handicap+12.9)) * dispersionFactor(handicap)
     }
 
     fun averageArrowScoreForHandicap(handicap: Int): BigDecimal {
@@ -116,7 +116,7 @@ class HandicapCalculator {
             var zoneRadiusSquared = (radius + arrowRadius).pow(2)
             exponentTotals += BigDecimal.valueOf(exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
         }
-        return (bestArrowScore - exponentTotals).setScale(2, RoundingMode.HALF_UP)
+        return (bestArrowScore - exponentTotals)
     }
 
     private fun imperialCalc(zoneMap: Map<Int, BigDecimal>, groupRadiusSquared: BigDecimal, bestArrowScore: BigDecimal, zoneScoreStep: Int): BigDecimal {
@@ -130,13 +130,16 @@ class HandicapCalculator {
                 exponentTotals += BigDecimal.valueOf(zoneScoreStep * exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
             }
         }
-        return (bestArrowScore - exponentTotals).setScale(2, RoundingMode.HALF_UP)
+        return (bestArrowScore - exponentTotals)
     }
 
     fun handicapScoresList(): List<Int> {
         var handicapList = ArrayList<Int>()
         for (handicap: Int in 0..100) {
-            handicapList.add((BigDecimal(arrowCount) * averageArrowScoreForHandicap(handicap).setScale(2, RoundingMode.UP)).setScale(0, RoundingMode.UP).toInt())
+//            handicapList.add((BigDecimal(arrowCount) * averageArrowScoreForHandicap(handicap).setScale(2, RoundingMode.HALF_UP)).setScale(0, RoundingMode.UP).toInt())
+            var average = averageArrowScoreForHandicap(handicap)
+            var roundScore = (BigDecimal(arrowCount) * average)
+            handicapList.add(roundScore.setScale(0, RoundingMode.HALF_UP).toInt())
         }
         return handicapList
     }
@@ -144,7 +147,7 @@ class HandicapCalculator {
     fun getHandicap(score: Int): Int {
         var scoreList = handicapScoresList()
         for (handicap: Int in 0..100) {
-            if (score > scoreList.get(handicap)) {
+            if (score >= scoreList.get(handicap)) {
                 return  handicap
             }
         }

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -4,22 +4,22 @@ import java.math.BigDecimal
 import kotlin.math.pow
 
 class HandicapCalculator {
+    private lateinit var targetDistance: Dimension
+    private lateinit var metricDistance: BigDecimal
     private val yards2metres = 0.9144
     private val inch2centimetre = 2.54
 
     private var handicap: Int = 0
     private var handicapCoefficient: Double = 0.0
-    private var targetDistanceYards: Int = 0
     private var targetDistanceMetres: Double = 0.0
-    private var isMetric: Boolean = true
 
 
-    fun targetDistanceMetres(): Any {
-        return targetDistanceMetres
+    fun metricDistance(): BigDecimal {
+        return metricDistance
     }
 
-    fun targetDistanceYards(): Any {
-        return targetDistanceYards
+    fun targetDistance(): Dimension {
+        return targetDistance
     }
 
     fun handicap(): Int {
@@ -30,18 +30,13 @@ class HandicapCalculator {
         return handicapCoefficient
     }
 
-    fun setTargetDistanceYards(yards: Int) {
-        this.targetDistanceYards = yards
-        this.targetDistanceMetres = yardsToMetres(yards)
-        this.isMetric = false
-    }
-
     fun yardsToMetres(yards: Int): Double {
         return yards * yards2metres
     }
 
-    fun setTargetDistanceMetres(metres: Int) {
-        this.targetDistanceMetres = metres.toDouble()
+    fun setTargetDistance(distanceDimension: Dimension) {
+        targetDistance = distanceDimension
+        this.metricDistance = BigDecimal.valueOf(distanceDimension.convertTo(Dimension.Unit.METER).value.toDouble())
     }
 
     fun setHandicap(handicap: Int) {
@@ -61,11 +56,6 @@ class HandicapCalculator {
 
     fun dispersionFactorYards(handicap: Int, yards: Int): Double {
         return dispersionFactor(handicap, yardsToMetres(yards))
-    }
-
-    fun isMetric(): Boolean {
-        return isMetric
-
     }
 
     fun angularDeviation(): BigDecimal {

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -26,42 +26,32 @@ import java.math.RoundingMode
 import kotlin.math.pow
 
 class HandicapCalculator {
-    constructor(round: Round, targetDiameter: Dimension) {
+    constructor(round: Round) {
         this.arrowCount = round.shotsPerEnd * round.maxEndCount!!
         this.targetModel = round.target.model
         this.scoringStyleIndex = round.target.scoringStyleIndex
-//        this.targetSizeIndex =
-//        setTargetDistance(round.distance)
+        this.targetSize = round.target.diameter
+        setTargetDistance(round.distance)
     }
     constructor()
 
-    private var arrowCount: Int = 1
-    private lateinit var targetModel: TargetModelBase
-    private var targetSize: Dimension = Dimension.UNKNOWN
-    private var scoringStyleIndex: Int = 0
-    private lateinit var targetDistance: Dimension
-    private lateinit var metricDistance: BigDecimal
-    private val yards2metres = 0.9144
-    private val inch2centimetre = 2.54
+    var arrowCount: Int = 1
+        private set
+    lateinit var targetModel: TargetModelBase
+        private set
+    var targetSize: Dimension = Dimension.UNKNOWN
+        private set
+    var scoringStyleIndex: Int = 0
+        private set
+    lateinit var targetDistance: Dimension
+        private set
+    lateinit var metricDistance: BigDecimal
+        private set
+    var arrowRadius = BigDecimal("0.357")
+        private set
 
-    private var handicap: Int = 0
-    private var arrowRadius = BigDecimal("0.357")
-
-
-    fun metricDistance(): BigDecimal {
-        return metricDistance
-    }
-
-    fun targetDistance(): Dimension {
-        return targetDistance
-    }
-
-    fun handicap(): Int {
-        return handicap
-    }
-
-    fun yardsToMetres(yards: Int): Double {
-        return yards * yards2metres
+    fun setArrowCount(arrowCount: Int) {
+        this.arrowCount = arrowCount
     }
 
     fun setTargetDistance(distanceDimension: Dimension) {
@@ -69,9 +59,22 @@ class HandicapCalculator {
         this.metricDistance = BigDecimal.valueOf(distanceDimension.convertTo(Dimension.Unit.METER).value.toDouble())
     }
 
-    fun setArrowCount(arrowCount: Int) {
-        this.arrowCount = arrowCount
+    fun setScoringStyleIndex(scoringStyleIndex: Int) {
+        this.scoringStyleIndex = scoringStyleIndex
     }
+
+    fun setTargetSize(dimension: Dimension) {
+        this.targetSize = targetModel.getRealSize(dimension)
+    }
+
+    fun setTargetModel(targetModel: TargetModelBase) {
+        this.targetModel = targetModel
+    }
+
+    fun setArrowRadius(newArrowRadius: BigDecimal) {
+        this.arrowRadius = newArrowRadius
+    }
+
 
     fun handicapCoefficient(handicap: Int) :Double {
         //K=1.429*10^-6 * 1.07^(handicap+4.3)
@@ -90,18 +93,6 @@ class HandicapCalculator {
     fun groupRadius(handicap: Int): BigDecimal {
         //sigma=groupRadiusCm==100*distance_in_metres*(1.036^(handicap+12.9))*5*(10^-4)*Dispersion_Factor
         return BigDecimal("0.05") * metricDistance * BigDecimal.valueOf(1.036.pow(handicap+12.9)) * dispersionFactor(handicap)
-    }
-
-    fun setScoringStyleIndex(scoringStyleIndex: Int) {
-        this.scoringStyleIndex = scoringStyleIndex
-    }
-
-    fun setTargetSize(dimension: Dimension) {
-        this.targetSize = targetModel.getRealSize(dimension)
-    }
-
-    fun setTargetModel(targetModel: TargetModelBase) {
-        this.targetModel = targetModel
     }
 
     fun averageArrowScoreForHandicap(handicap: Int): BigDecimal {
@@ -140,10 +131,6 @@ class HandicapCalculator {
             }
         }
         return bestArrowScore - exponentTotals
-    }
-
-    fun setArrowRadius(newArrowRadius: BigDecimal) {
-        this.arrowRadius = newArrowRadius
     }
 
     fun handicapScoresList(): List<Int> {

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -32,12 +32,15 @@ class HandicapCalculator {
         this.targetModel = round.target.model
         this.scoringStyle = round.target.getScoringStyle()
         this.targetSize = round.target.diameter
-        this.scoreForRound = round.score.totalPoints
+        this.maxScore = round.score.totalPoints
+        this.reachedScore = round.score.reachedPoints
         setTargetDistance(round.distance)
     }
     constructor()
 
-    var scoreForRound: Int = 0
+    var reachedScore: Int = 0
+        private set
+    var maxScore: Int = 0
         private set
     var arrowCount: Int = 1
         private set
@@ -167,7 +170,7 @@ class HandicapCalculator {
     }
 
     fun getHandicap(): Int {
-        return getHandicapForScore(this.scoreForRound)
+        return getHandicapForScore(this.reachedScore)
     }
 
 //arrowDiameterCm=arrow_diameter_cm  (0.357cm) 18/64

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -3,9 +3,11 @@ package de.dreier.mytargets.shared.models
 import de.dreier.mytargets.shared.targets.models.TargetModelBase
 import java.lang.Math.exp
 import java.math.BigDecimal
+import java.math.RoundingMode
 import kotlin.math.pow
 
 class HandicapCalculator {
+    private var arrowCount: Int = 1
     private lateinit var targetModel: TargetModelBase
     private var targetSizeIndex: Int = 0
     private var scoringStyleIndex: Int = 0
@@ -37,6 +39,10 @@ class HandicapCalculator {
     fun setTargetDistance(distanceDimension: Dimension) {
         targetDistance = distanceDimension
         this.metricDistance = BigDecimal.valueOf(distanceDimension.convertTo(Dimension.Unit.METER).value.toDouble())
+    }
+
+    fun setArrowCount(arrowCount: Int) {
+        this.arrowCount = arrowCount
     }
 
     fun handicapCoefficient(handicap: Int) :Double {
@@ -109,6 +115,25 @@ class HandicapCalculator {
 
     fun setArrowRadius(newArrowRadius: BigDecimal) {
         this.arrowRadius = newArrowRadius
+    }
+
+    fun handicapScoresList(): List<Int> {
+        var handicapList = ArrayList<Int>()
+        for (handicap: Int in 0..100) {
+            handicapList.add((BigDecimal(arrowCount) * averageArrowScoreForHandicap(handicap)).setScale(0, RoundingMode.UP).toInt())
+        }
+        return handicapList
+    }
+
+    fun getHandicap(score: Int): Int {
+        var scoreList = handicapScoresList()
+        for (handicap: Int in 0..100) {
+            if (score > scoreList.get(handicap)) {
+                return  handicap
+            }
+        }
+        return 101
+
     }
 //arrowDiameterCm=arrow_diameter_cm  (0.357cm) 18/64
 //targetSizeCm=target_size_cm (122)

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -1,9 +1,14 @@
 package de.dreier.mytargets.shared.models
 
+import de.dreier.mytargets.shared.targets.models.TargetModelBase
+import java.lang.Math.exp
 import java.math.BigDecimal
 import kotlin.math.pow
 
 class HandicapCalculator {
+    private lateinit var targetModel: TargetModelBase
+    private var targetSizeIndex: Int = 0
+    private var scoringStyleIndex: Int = 0
     private lateinit var targetDistance: Dimension
     private lateinit var metricDistance: BigDecimal
     private val yards2metres = 0.9144
@@ -63,5 +68,63 @@ class HandicapCalculator {
         return BigDecimal("0.05") * metricDistance * BigDecimal.valueOf(1.036.pow(handicap+12.9)) * dispersionFactor()
     }
 
+    fun setScoringStyleIndex(scoringStyleIndex: Int) {
+        this.scoringStyleIndex = scoringStyleIndex
+    }
 
+    fun setTargetSizeIndex(targetSizeIndex: Int) {
+        this.targetSizeIndex = targetSizeIndex
+    }
+
+    fun setTargetModel(targetModel: TargetModelBase) {
+        this.targetModel = targetModel
+    }
+
+    fun averageArrowScore(): BigDecimal {
+    //10-zone-Average_Arrow_Score=10 - (EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((7*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((8*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((9*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((10*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2))
+        var arrowDiameter = BigDecimal("0.357")
+        var groupRadiusSquared = groupRadius().pow(2)
+        var zoneMap = targetModel.getZoneSizeMapFromProperties(scoringStyleIndex, targetSizeIndex)
+
+        var bestArrowScore = BigDecimal("10")
+
+        var exponentTotals = BigDecimal(0)
+        for ((index, radius) in zoneMap.iterator()) {
+            var zoneRadiusSquared = (radius + arrowDiameter).pow(2)
+            exponentTotals += BigDecimal.valueOf(exp(-(zoneRadiusSquared/groupRadiusSquared).toDouble()))
+        }
+
+        return bestArrowScore - exponentTotals
+    }
+
+
+//arrowDiameterCm=arrow_diameter_cm  (0.357cm) 18/64
+//targetSizeCm=target_size_cm (122)
+//targetDistanceMetres=distance_m (70)
+//
+
+//15y=13.716m
+
+//SizeOfZone = 1*targetSizeCm/20.....
+
+    //10-zone-Average_Arrow_Score=10 - (
+    // EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) +
+    // EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) +
+    // EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) +
+    // EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) +
+    // EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) +
+    // EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) +
+    // EXP(-(((7*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) +
+    // EXP(-(((8*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) +
+    // EXP(-(((9*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) +
+    // EXP(-(((10*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2))
+
+//10-zone-Average_Arrow_Score=10 - (EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((7*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((8*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((9*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((10*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2))
+//10-zone-compound-wa-pmoth  =10 - (EXP(-(((1*targetSizeCm/40)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((7*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((8*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((9*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((10*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2))
+//5-zone-avg-arrow=          =9 - 2*(EXP(-(((1*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2)) - EXP(-(((5*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2)
+//10-zone-trispot==10 - (EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2)) - 6* EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2)
+//6-zone-fita=10 - (EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2)) - 5* EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2)
+//worcester=5 - (EXP(-(((1*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2))
+//wa-field=6 - EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) - (EXP(-(((2*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2))
+//beiter-hit-miss=1 - EXP(-(((1*targetSizeCm/2)+arrowDiameterCm)^2)/groupRadiusCm^2)
 }

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -143,18 +143,20 @@ class HandicapCalculator {
         return (bestArrowScore - exponentTotals)
     }
 
-    fun handicapScoresList(): List<Int> {
-        var handicapList = ArrayList<Int>()
+    fun handicapScoresList(rounded: Boolean = true): List<BigDecimal> {
+        val decimalPlaces: Int = if (rounded) 0 else 2
+        var handicapList = ArrayList<BigDecimal>()
         for (handicap: Int in  handicapLowerBound()..handicapUpperBound()) {
 //            handicapList.add((BigDecimal(arrowCount) * averageArrowScoreForHandicap(handicap).setScale(2, RoundingMode.HALF_UP)).setScale(0, RoundingMode.UP).toInt())
             var average = averageArrowScoreForHandicap(handicap)
             var roundScore = (BigDecimal(arrowCount) * average)
-            handicapList.add(roundScore.setScale(0, RoundingMode.HALF_UP).toInt())
+            handicapList.add(roundScore.setScale(decimalPlaces, RoundingMode.HALF_UP))
         }
         return handicapList
     }
 
-    fun getHandicapForScore(score: Int): Int {
+    fun getHandicapForScore(totalScore: Int): Int {
+        val score = BigDecimal(totalScore.toString())
         var scoreList = handicapScoresList()
         for (handicap: Int in  handicapLowerBound()..handicapUpperBound()) {
             if (score >= scoreList.get(handicap)) {
@@ -167,6 +169,7 @@ class HandicapCalculator {
     fun getHandicap(): Int {
         return getHandicapForScore(this.scoreForRound)
     }
+
 //arrowDiameterCm=arrow_diameter_cm  (0.357cm) 18/64
 //targetSizeCm=target_size_cm (122)
 //targetDistanceMetres=distance_m (70)

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -49,17 +49,18 @@ class HandicapCalculator {
         return 1.429*(10.00.pow(-6))*1.07.pow(handicap+4.3)
     }
 
-    fun dispersionFactor(handicap: Int, distance: Double): Double {
+    fun dispersionFactor(handicap: Int, distance: BigDecimal): BigDecimal {
         //F=1 + 1.429*10^-6 * 1.07^(handicap+4.3) * distance_in_metres^2
-        return 1+1.429*(10.0.pow(-6)) * 1.07.pow(handicap+4.3) * distance.pow(2)
-    }
-
-    fun dispersionFactorYards(handicap: Int, yards: Int): Double {
-        return dispersionFactor(handicap, yardsToMetres(yards))
+        return BigDecimal.valueOf(1 + 1.429 * (10.0.pow(-6)) * 1.07.pow(handicap+4.3) * distance.toDouble().pow(2))
     }
 
     fun angularDeviation(): BigDecimal {
        return  BigDecimal.valueOf((1.036.pow(handicap+12.9))*5*(10.0.pow(-4))*180/Math.PI)
+    }
+
+    fun groupRadius(): BigDecimal {
+    //sigma=groupRadiusCm==100*distance_in_metres*(1.036^(handicap+12.9))*5*(10^-4)*Dispersion_Factor
+        return BigDecimal(100* metricDistance.toDouble() * 1.036.pow(handicap+12.9) * 5 * 10.0.pow(-4)) * dispersionFactor(handicap, metricDistance)
     }
 
 

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -59,8 +59,8 @@ class HandicapCalculator {
     }
 
     fun groupRadius(): BigDecimal {
-    //sigma=groupRadiusCm==100*distance_in_metres*(1.036^(handicap+12.9))*5*(10^-4)*Dispersion_Factor
-        return BigDecimal(100* metricDistance.toDouble() * 1.036.pow(handicap+12.9) * 5 * 10.0.pow(-4)) * dispersionFactor()
+        //sigma=groupRadiusCm==100*distance_in_metres*(1.036^(handicap+12.9))*5*(10^-4)*Dispersion_Factor
+        return BigDecimal("0.05") * metricDistance * BigDecimal.valueOf(1.036.pow(handicap+12.9)) * dispersionFactor()
     }
 
 

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -49,9 +49,9 @@ class HandicapCalculator {
         return 1.429*(10.00.pow(-6))*1.07.pow(handicap+4.3)
     }
 
-    fun dispersionFactor(handicap: Int, distance: BigDecimal): BigDecimal {
+    fun dispersionFactor(): BigDecimal {
         //F=1 + 1.429*10^-6 * 1.07^(handicap+4.3) * distance_in_metres^2
-        return BigDecimal.valueOf(1 + 1.429 * (10.0.pow(-6)) * 1.07.pow(handicap+4.3) * distance.toDouble().pow(2))
+        return BigDecimal.valueOf(1 + 1.429 * (10.0.pow(-6)) * 1.07.pow(handicap+4.3) * metricDistance.toDouble().pow(2))
     }
 
     fun angularDeviation(): BigDecimal {
@@ -60,7 +60,7 @@ class HandicapCalculator {
 
     fun groupRadius(): BigDecimal {
     //sigma=groupRadiusCm==100*distance_in_metres*(1.036^(handicap+12.9))*5*(10^-4)*Dispersion_Factor
-        return BigDecimal(100* metricDistance.toDouble() * 1.036.pow(handicap+12.9) * 5 * 10.0.pow(-4)) * dispersionFactor(handicap, metricDistance)
+        return BigDecimal(100* metricDistance.toDouble() * 1.036.pow(handicap+12.9) * 5 * 10.0.pow(-4)) * dispersionFactor()
     }
 
 

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -1,5 +1,6 @@
 package de.dreier.mytargets.shared.models
 
+import java.math.BigDecimal
 import kotlin.math.pow
 
 class HandicapCalculator {
@@ -66,5 +67,10 @@ class HandicapCalculator {
         return isMetric
 
     }
+
+    fun angularDeviation(): BigDecimal {
+       return  BigDecimal.valueOf((1.036.pow(handicap+12.9))*5*(10.0.pow(-4))*180/Math.PI)
+    }
+
 
 }

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -1,9 +1,10 @@
-package de.dreier.mytargets.features.statistics
+package de.dreier.mytargets.shared.models
 
 import kotlin.math.pow
 
 class HandicapCalculator {
     private val yards2metres = 0.9144
+    private val inch2centimetre = 2.54
 
     private var handicap: Int = 0
     private var handicapCoefficient: Double = 0.0

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -1,9 +1,9 @@
 /*
  * MyTargets Project Copyright (C) 2018 Florian Dreier
  *
- * This file is (c) 2021 Jez McKinley
+ * This file is (c) 2021 Jez McKinley - Canford Magna Bowmen
  *
- * Calculations used in this file are courtesy of Jack Atkinson - see:
+* Calculations used in this file are courtesy of Jack Atkinson - see:
  * https://www.jackatkinson.net/post/archery_handicap/
  * derived from David Lane's Handicap Calcs for Toxophilus 1979
  *

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -17,6 +17,7 @@ class HandicapCalculator {
     private var handicap: Int = 0
     private var handicapCoefficient: Double = 0.0
     private var targetDistanceMetres: Double = 0.0
+    private var arrowRadius = BigDecimal("0.357")
 
 
     fun metricDistance(): BigDecimal {
@@ -82,33 +83,32 @@ class HandicapCalculator {
 
     fun averageArrowScore(): BigDecimal {
     //10-zone-Average_Arrow_Score=10 - (EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((7*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((8*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((9*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((10*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2))
-        var arrowRadius = BigDecimal("0.357")
         val groupRadiusSquared = groupRadius().pow(2)
         val zoneMap = targetModel.getZoneSizeMapFromProperties(scoringStyleIndex, targetSizeIndex)
         val bestArrowScore = BigDecimal(zoneMap.keys.max().toString())
 
         var zoneScoreStep = (zoneMap.keys.elementAt(0) - zoneMap.keys.elementAt(1))
         if (zoneScoreStep == 2) {
-            return imperialCalc(zoneMap, arrowRadius, groupRadiusSquared, bestArrowScore, zoneScoreStep)
+            return imperialCalc(zoneMap, groupRadiusSquared, bestArrowScore, zoneScoreStep)
         } else {
-            return metricCalc(zoneMap, arrowRadius, groupRadiusSquared, bestArrowScore)
+            return metricCalc(zoneMap, groupRadiusSquared, bestArrowScore)
         }
     }
 
-    private fun metricCalc(zoneMap: Map<Int, BigDecimal>, arrowDiameter: BigDecimal, groupRadiusSquared: BigDecimal, bestArrowScore: BigDecimal): BigDecimal {
+    private fun metricCalc(zoneMap: Map<Int, BigDecimal>, groupRadiusSquared: BigDecimal, bestArrowScore: BigDecimal): BigDecimal {
         var exponentTotals = BigDecimal(0)
         for ((index, radius) in zoneMap.iterator()) {
-            var zoneRadiusSquared = (radius + arrowDiameter).pow(2)
+            var zoneRadiusSquared = (radius + arrowRadius).pow(2)
             exponentTotals += BigDecimal.valueOf(exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
         }
         return bestArrowScore - exponentTotals
     }
 
-    private fun imperialCalc(zoneMap: Map<Int, BigDecimal>, arrowDiameter: BigDecimal, groupRadiusSquared: BigDecimal, bestArrowScore: BigDecimal, zoneScoreStep: Int): BigDecimal {
+    private fun imperialCalc(zoneMap: Map<Int, BigDecimal>, groupRadiusSquared: BigDecimal, bestArrowScore: BigDecimal, zoneScoreStep: Int): BigDecimal {
         var exponentTotals = BigDecimal(0)
         var lastEntry = zoneMap.entries.last()
         for ((index, radius) in zoneMap.iterator()) {
-            var zoneRadiusSquared = (radius + arrowDiameter).pow(2)
+            var zoneRadiusSquared = (radius + arrowRadius).pow(2)
             if (radius == lastEntry.value) {
                 exponentTotals -= BigDecimal.valueOf(exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
             } else {
@@ -118,8 +118,8 @@ class HandicapCalculator {
         return bestArrowScore - exponentTotals
     }
 
-    fun setArrowRadius(bigDecimal: BigDecimal) {
-
+    fun setArrowRadius(newArrowRadius: BigDecimal) {
+        this.arrowRadius = newArrowRadius
     }
 //arrowDiameterCm=arrow_diameter_cm  (0.357cm) 18/64
 //targetSizeCm=target_size_cm (122)

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -71,8 +71,8 @@ class HandicapCalculator {
         this.targetModel = targetModel
     }
 
-    fun setArrowRadius(newArrowRadius: BigDecimal) {
-        this.arrowRadius = newArrowRadius
+    fun setArrowRadius(arrowRadius: BigDecimal) {
+        this.arrowRadius = arrowRadius
     }
 
 
@@ -83,7 +83,7 @@ class HandicapCalculator {
 
     fun dispersionFactor(handicap: Int): BigDecimal {
         //F=1 + 1.429*10^-6 * 1.07^(handicap+4.3) * distance_in_metres^2
-        return BigDecimal.valueOf(1 + 1.429 * (10.0.pow(-6)) * 1.07.pow(handicap+4.3) * metricDistance.toDouble().pow(2))
+        return BigDecimal.valueOf(1 + 1.429 * (10.0.pow(-6)) * 1.07.pow(handicap+4.3) * metricDistance.toDouble().pow(2)).setScale(14, RoundingMode.HALF_UP)
     }
 
     fun angularDeviation(handicap: Int): BigDecimal {
@@ -92,7 +92,7 @@ class HandicapCalculator {
 
     fun groupRadius(handicap: Int): BigDecimal {
         //sigma=groupRadiusCm==100*distance_in_metres*(1.036^(handicap+12.9))*5*(10^-4)*Dispersion_Factor
-        return BigDecimal("0.05") * metricDistance * BigDecimal.valueOf(1.036.pow(handicap+12.9)) * dispersionFactor(handicap)
+        return BigDecimal("0.05") * metricDistance * BigDecimal.valueOf(1.036.pow(handicap+12.9)) * dispersionFactor(handicap).setScale(8, RoundingMode.HALF_UP)
     }
 
     fun averageArrowScoreForHandicap(handicap: Int): BigDecimal {
@@ -116,7 +116,7 @@ class HandicapCalculator {
             var zoneRadiusSquared = (radius + arrowRadius).pow(2)
             exponentTotals += BigDecimal.valueOf(exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
         }
-        return bestArrowScore - exponentTotals
+        return (bestArrowScore - exponentTotals).setScale(2, RoundingMode.HALF_UP)
     }
 
     private fun imperialCalc(zoneMap: Map<Int, BigDecimal>, groupRadiusSquared: BigDecimal, bestArrowScore: BigDecimal, zoneScoreStep: Int): BigDecimal {
@@ -130,13 +130,13 @@ class HandicapCalculator {
                 exponentTotals += BigDecimal.valueOf(zoneScoreStep * exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
             }
         }
-        return bestArrowScore - exponentTotals
+        return (bestArrowScore - exponentTotals).setScale(2, RoundingMode.HALF_UP)
     }
 
     fun handicapScoresList(): List<Int> {
         var handicapList = ArrayList<Int>()
         for (handicap: Int in 0..100) {
-            handicapList.add((BigDecimal(arrowCount) * averageArrowScoreForHandicap(handicap)).setScale(0, RoundingMode.UP).toInt())
+            handicapList.add((BigDecimal(arrowCount) * averageArrowScoreForHandicap(handicap).setScale(2, RoundingMode.UP)).setScale(0, RoundingMode.UP).toInt())
         }
         return handicapList
     }

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -82,22 +82,45 @@ class HandicapCalculator {
 
     fun averageArrowScore(): BigDecimal {
     //10-zone-Average_Arrow_Score=10 - (EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((7*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((8*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((9*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((10*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2))
-        var arrowDiameter = BigDecimal("0.357")
-        var groupRadiusSquared = groupRadius().pow(2)
-        var zoneMap = targetModel.getZoneSizeMapFromProperties(scoringStyleIndex, targetSizeIndex)
+        var arrowRadius = BigDecimal("0.357")
+        val groupRadiusSquared = groupRadius().pow(2)
+        val zoneMap = targetModel.getZoneSizeMapFromProperties(scoringStyleIndex, targetSizeIndex)
+        val bestArrowScore = BigDecimal(zoneMap.keys.max().toString())
 
-        var bestArrowScore = BigDecimal("10")
+        var zoneScoreStep = (zoneMap.keys.elementAt(0) - zoneMap.keys.elementAt(1))
+        if (zoneScoreStep == 2) {
+            return imperialCalc(zoneMap, arrowRadius, groupRadiusSquared, bestArrowScore, zoneScoreStep)
+        } else {
+            return metricCalc(zoneMap, arrowRadius, groupRadiusSquared, bestArrowScore)
+        }
+    }
 
+    private fun metricCalc(zoneMap: Map<Int, BigDecimal>, arrowDiameter: BigDecimal, groupRadiusSquared: BigDecimal, bestArrowScore: BigDecimal): BigDecimal {
         var exponentTotals = BigDecimal(0)
         for ((index, radius) in zoneMap.iterator()) {
             var zoneRadiusSquared = (radius + arrowDiameter).pow(2)
-            exponentTotals += BigDecimal.valueOf(exp(-(zoneRadiusSquared/groupRadiusSquared).toDouble()))
+            exponentTotals += BigDecimal.valueOf(exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
         }
-
         return bestArrowScore - exponentTotals
     }
 
+    private fun imperialCalc(zoneMap: Map<Int, BigDecimal>, arrowDiameter: BigDecimal, groupRadiusSquared: BigDecimal, bestArrowScore: BigDecimal, zoneScoreStep: Int): BigDecimal {
+        var exponentTotals = BigDecimal(0)
+        var lastEntry = zoneMap.entries.last()
+        for ((index, radius) in zoneMap.iterator()) {
+            var zoneRadiusSquared = (radius + arrowDiameter).pow(2)
+            if (radius == lastEntry.value) {
+                exponentTotals -= BigDecimal.valueOf(exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
+            } else {
+                exponentTotals += BigDecimal.valueOf(zoneScoreStep * exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
+            }
+        }
+        return bestArrowScore - exponentTotals
+    }
 
+    fun setArrowRadius(bigDecimal: BigDecimal) {
+
+    }
 //arrowDiameterCm=arrow_diameter_cm  (0.357cm) 18/64
 //targetSizeCm=target_size_cm (122)
 //targetDistanceMetres=distance_m (70)
@@ -119,6 +142,15 @@ class HandicapCalculator {
     // EXP(-(((9*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) +
     // EXP(-(((10*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2))
 
+//5-zone-avg-arrow=          =9 -
+// 2*(
+// EXP(-(((1*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) +
+// EXP(-(((2*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) +
+// EXP(-(((3*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) +
+// EXP(-(((4*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2)) -
+// EXP(-(((5*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2)
+
+//10-zone-compound-wa-pmoth  =10 - (EXP(-(((1*targetSizeCm/40)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((7*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((8*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((9*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((10*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2))
 //10-zone-Average_Arrow_Score=10 - (EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((7*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((8*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((9*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((10*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2))
 //10-zone-compound-wa-pmoth  =10 - (EXP(-(((1*targetSizeCm/40)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((7*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((8*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((9*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((10*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2))
 //5-zone-avg-arrow=          =9 - 2*(EXP(-(((1*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2)) - EXP(-(((5*targetSizeCm/10)+arrowDiameterCm)^2)/groupRadiusCm^2)

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -20,6 +20,7 @@ package de.dreier.mytargets.shared.models
 
 import de.dreier.mytargets.shared.models.db.Round
 import de.dreier.mytargets.shared.targets.models.TargetModelBase
+import de.dreier.mytargets.shared.targets.scoringstyle.ScoringStyle
 import java.lang.Math.exp
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -29,7 +30,7 @@ class HandicapCalculator {
     constructor(round: Round) {
         this.arrowCount = round.shotsPerEnd * round.maxEndCount!!
         this.targetModel = round.target.model
-        this.scoringStyleIndex = round.target.scoringStyleIndex
+        this.scoringStyle = round.target.getScoringStyle()
         this.targetSize = round.target.diameter
         setTargetDistance(round.distance)
     }
@@ -41,7 +42,7 @@ class HandicapCalculator {
         private set
     var targetSize: Dimension = Dimension.UNKNOWN
         private set
-    var scoringStyleIndex: Int = 0
+    lateinit var scoringStyle: ScoringStyle
         private set
     lateinit var targetDistance: Dimension
         private set
@@ -59,8 +60,8 @@ class HandicapCalculator {
         this.metricDistance = BigDecimal.valueOf(distanceDimension.convertTo(Dimension.Unit.METER).value.toDouble())
     }
 
-    fun setScoringStyleIndex(scoringStyleIndex: Int) {
-        this.scoringStyleIndex = scoringStyleIndex
+    fun setScoringStyle(scoringStyle: ScoringStyle) {
+        this.scoringStyle = scoringStyle
     }
 
     fun setTargetSize(dimension: Dimension) {
@@ -98,7 +99,6 @@ class HandicapCalculator {
     fun averageArrowScoreForHandicap(handicap: Int): BigDecimal {
     //10-zone-Average_Arrow_Score=10 - (EXP(-(((1*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((2*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((3*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((4*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((5*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((6*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((7*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((8*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((9*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2) + EXP(-(((10*targetSizeCm/20)+arrowDiameterCm)^2)/groupRadiusCm^2))
         val groupRadiusSquared = groupRadius(handicap).pow(2)
-        val scoringStyle = targetModel.getScoringStyle(scoringStyleIndex)
         val zoneMap = targetModel.getZoneSizeMap(scoringStyle, targetSize)
         val bestArrowScore = BigDecimal(zoneMap.keys.max().toString())
 

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -32,10 +32,13 @@ class HandicapCalculator {
         this.targetModel = round.target.model
         this.scoringStyle = round.target.getScoringStyle()
         this.targetSize = round.target.diameter
+        this.scoreForRound = round.score.totalPoints
         setTargetDistance(round.distance)
     }
     constructor()
 
+    var scoreForRound: Int = 0
+        private set
     var arrowCount: Int = 1
         private set
     lateinit var targetModel: TargetModelBase
@@ -50,6 +53,13 @@ class HandicapCalculator {
         private set
     var arrowRadius = BigDecimal("0.357")
         private set
+
+    companion object {
+        @JvmStatic
+        fun handicapLowerBound() : Int = 0
+        @JvmStatic
+        fun handicapUpperBound() : Int = 100
+    }
 
     fun setArrowCount(arrowCount: Int) {
         this.arrowCount = arrowCount
@@ -135,7 +145,7 @@ class HandicapCalculator {
 
     fun handicapScoresList(): List<Int> {
         var handicapList = ArrayList<Int>()
-        for (handicap: Int in 0..100) {
+        for (handicap: Int in  handicapLowerBound()..handicapUpperBound()) {
 //            handicapList.add((BigDecimal(arrowCount) * averageArrowScoreForHandicap(handicap).setScale(2, RoundingMode.HALF_UP)).setScale(0, RoundingMode.UP).toInt())
             var average = averageArrowScoreForHandicap(handicap)
             var roundScore = (BigDecimal(arrowCount) * average)
@@ -144,15 +154,18 @@ class HandicapCalculator {
         return handicapList
     }
 
-    fun getHandicap(score: Int): Int {
+    fun getHandicapForScore(score: Int): Int {
         var scoreList = handicapScoresList()
-        for (handicap: Int in 0..100) {
+        for (handicap: Int in  handicapLowerBound()..handicapUpperBound()) {
             if (score >= scoreList.get(handicap)) {
                 return  handicap
             }
         }
         return 101
+    }
 
+    fun getHandicap(): Int {
+        return getHandicapForScore(this.scoreForRound)
     }
 //arrowDiameterCm=arrow_diameter_cm  (0.357cm) 18/64
 //targetSizeCm=target_size_cm (122)

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/MultiRoundHandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/MultiRoundHandicapCalculator.kt
@@ -1,0 +1,46 @@
+package de.dreier.mytargets.shared.models
+
+import de.dreier.mytargets.shared.models.db.Round
+
+class MultiRoundHandicapCalculator{
+    private lateinit var rounds: List<Round>
+
+    constructor(roundList: List<Round>) {
+       this.rounds = roundList
+    }
+
+    fun handicapScoresList(): List<Int> {
+        var handicapList = ArrayList<Int>()
+        var roundHandicapScoreLists = ArrayList<List<Int>>()
+        for (round: Round in rounds) {
+            roundHandicapScoreLists.add(HandicapCalculator(round).handicapScoresList())
+        }
+        for (handicap: Int in  HandicapCalculator.handicapLowerBound()..HandicapCalculator.handicapUpperBound()) {
+            var totalForHandicap: Int = 0
+            for (roundHandicapScoreList: List<Int> in roundHandicapScoreLists) {
+                totalForHandicap += roundHandicapScoreList.get(handicap)
+            }
+            handicapList.add(totalForHandicap)
+        }
+        return  handicapList
+    }
+
+    fun getHandicapForScore(score: Int): Int {
+        var scoreList = handicapScoresList()
+        for (handicap: Int in  HandicapCalculator.handicapLowerBound()..HandicapCalculator.handicapUpperBound()) {
+            if (score >= scoreList.get(handicap)) {
+                return  handicap
+            }
+        }
+        return 101
+    }
+
+    fun getHandicap(): Int {
+        var totalScore: Int = 0
+        for (round: Round in rounds) {
+           totalScore += round.score.totalPoints
+        }
+        return getHandicapForScore(totalScore)
+    }
+
+}

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/MultiRoundHandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/MultiRoundHandicapCalculator.kt
@@ -1,31 +1,38 @@
 package de.dreier.mytargets.shared.models
 
 import de.dreier.mytargets.shared.models.db.Round
+import java.math.BigDecimal
+import java.math.RoundingMode
 
 class MultiRoundHandicapCalculator{
     private lateinit var rounds: List<Round>
+    private var roundHandicapScoreLists = ArrayList<List<BigDecimal>>()
+    private var totalScore: Int = 0
 
     constructor(roundList: List<Round>) {
        this.rounds = roundList
+        for (round: Round in rounds) {
+            totalScore += round.score.totalPoints
+        }
+        for (round: Round in rounds) {
+            roundHandicapScoreLists.add(HandicapCalculator(round).handicapScoresList(false))
+        }
     }
 
-    fun handicapScoresList(): List<Int> {
-        var handicapList = ArrayList<Int>()
-        var roundHandicapScoreLists = ArrayList<List<Int>>()
-        for (round: Round in rounds) {
-            roundHandicapScoreLists.add(HandicapCalculator(round).handicapScoresList())
-        }
+    fun handicapScoresList(): List<BigDecimal> {
+        var handicapList = ArrayList<BigDecimal>()
         for (handicap: Int in  HandicapCalculator.handicapLowerBound()..HandicapCalculator.handicapUpperBound()) {
-            var totalForHandicap: Int = 0
-            for (roundHandicapScoreList: List<Int> in roundHandicapScoreLists) {
+            var totalForHandicap: BigDecimal = BigDecimal("0")
+            for (roundHandicapScoreList: List<BigDecimal> in roundHandicapScoreLists) {
                 totalForHandicap += roundHandicapScoreList.get(handicap)
             }
-            handicapList.add(totalForHandicap)
+            handicapList.add(totalForHandicap.setScale(0, RoundingMode.DOWN))
         }
         return  handicapList
     }
 
-    fun getHandicapForScore(score: Int): Int {
+    fun getHandicapForScore(totalScore: Int): Int {
+        val score = BigDecimal(totalScore.toString())
         var scoreList = handicapScoresList()
         for (handicap: Int in  HandicapCalculator.handicapLowerBound()..HandicapCalculator.handicapUpperBound()) {
             if (score >= scoreList.get(handicap)) {
@@ -36,10 +43,6 @@ class MultiRoundHandicapCalculator{
     }
 
     fun getHandicap(): Int {
-        var totalScore: Int = 0
-        for (round: Round in rounds) {
-           totalScore += round.score.totalPoints
-        }
         return getHandicapForScore(totalScore)
     }
 

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/MultiRoundHandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/MultiRoundHandicapCalculator.kt
@@ -5,6 +5,7 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 
 class MultiRoundHandicapCalculator{
+    var arrowRadius: BigDecimal = BigDecimal("0.357")
     var rounds: List<Round>
         private set
     var roundHandicapScoreLists = ArrayList<List<BigDecimal>>()
@@ -14,14 +15,18 @@ class MultiRoundHandicapCalculator{
     var reachedScore: Int = 0
         private set
 
-    constructor(roundList: List<Round>) {
+    constructor(roundList: List<Round>, arrowDiameter: Dimension) {
         this.rounds = roundList
+        this.arrowRadius = BigDecimal((arrowDiameter.convertTo(Dimension.Unit.CENTIMETER).value / 2).toString()).setScale(3, RoundingMode.HALF_UP)
+
         for (round: Round in rounds) {
             totalScore += round.score.totalPoints
             reachedScore += round.score.reachedPoints
         }
         for (round: Round in rounds) {
-            roundHandicapScoreLists.add(HandicapCalculator(round).handicapScoresList(false))
+            var calulator = HandicapCalculator(round)
+            calulator.setArrowRadius(arrowRadius)
+            roundHandicapScoreLists.add(calulator.handicapScoresList(false))
         }
     }
 

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/MultiRoundHandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/MultiRoundHandicapCalculator.kt
@@ -5,14 +5,20 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 
 class MultiRoundHandicapCalculator{
-    private lateinit var rounds: List<Round>
-    private var roundHandicapScoreLists = ArrayList<List<BigDecimal>>()
-    private var totalScore: Int = 0
+    var rounds: List<Round>
+        private set
+    var roundHandicapScoreLists = ArrayList<List<BigDecimal>>()
+        private set
+    var totalScore: Int = 0
+        private set
+    var reachedScore: Int = 0
+        private set
 
     constructor(roundList: List<Round>) {
-       this.rounds = roundList
+        this.rounds = roundList
         for (round: Round in rounds) {
             totalScore += round.score.totalPoints
+            reachedScore += round.score.reachedPoints
         }
         for (round: Round in rounds) {
             roundHandicapScoreLists.add(HandicapCalculator(round).handicapScoresList(false))
@@ -43,7 +49,7 @@ class MultiRoundHandicapCalculator{
     }
 
     fun getHandicap(): Int {
-        return getHandicapForScore(totalScore)
+        return getHandicapForScore(reachedScore)
     }
 
 }

--- a/shared/src/main/java/de/dreier/mytargets/shared/targets/models/TargetModelBase.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/targets/models/TargetModelBase.kt
@@ -138,7 +138,7 @@ open class TargetModelBase protected constructor(
         return zoneMap
     }
 
-    fun getZoneSizeMapFromProperties(scoringStyleIndex: Int, targetSizeIndex: Int): Map<Int, BigDecimal> {
+    fun getZoneSizeMapFromIndices(scoringStyleIndex: Int, targetSizeIndex: Int): Map<Int, BigDecimal> {
         return getZoneSizeMap(scoringStyles[scoringStyleIndex], diameters[targetSizeIndex])
     }
 }

--- a/shared/src/main/java/de/dreier/mytargets/shared/targets/models/TargetModelBase.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/targets/models/TargetModelBase.kt
@@ -29,6 +29,7 @@ import de.dreier.mytargets.shared.targets.zone.CircularZone
 import de.dreier.mytargets.shared.targets.zone.ZoneBase
 import de.dreier.mytargets.shared.utils.Color
 import de.dreier.mytargets.shared.utils.Color.BLACK
+import java.math.BigDecimal
 import java.util.*
 
 open class TargetModelBase protected constructor(
@@ -122,5 +123,28 @@ open class TargetModelBase protected constructor(
             }
         }
         return list
+    }
+
+
+
+    fun getZoneSizeMapByIndex(scoringStyleIndex: Int, targetDimensionIndex: Int): Map<Int, Float> {
+        var zoneMap = HashMap<Int, Float>()
+        return zoneMap
+    }
+
+    fun getZoneSizeMap(scoringStyle: ScoringStyle, targetSize: Dimension): Map<Int, BigDecimal> {
+        var zoneMap = HashMap<Int, BigDecimal>()
+        var targetRadius = targetSize.value.toBigDecimal().div(BigDecimal.valueOf(2))
+        // TODO: convert to unit in a bit
+        for ((zoneIndex, score) in scoringStyle.getPointsList().iterator().withIndex()) {
+                var radius = zones.get(zoneIndex).radius.toBigDecimal().times(targetRadius)
+                zoneMap.put(score, radius)
+        }
+
+        return zoneMap
+    }
+
+    fun getZoneSizeMapFromProperties(scoringStyleIndex: Int, targetSizeIndex: Int): Map<Int, BigDecimal> {
+        return getZoneSizeMap(scoringStyles[scoringStyleIndex], diameters[targetSizeIndex])
     }
 }

--- a/shared/src/main/java/de/dreier/mytargets/shared/targets/models/TargetModelBase.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/targets/models/TargetModelBase.kt
@@ -126,14 +126,8 @@ open class TargetModelBase protected constructor(
     }
 
 
-
-    fun getZoneSizeMapByIndex(scoringStyleIndex: Int, targetDimensionIndex: Int): Map<Int, Float> {
-        var zoneMap = HashMap<Int, Float>()
-        return zoneMap
-    }
-
     fun getZoneSizeMap(scoringStyle: ScoringStyle, targetSize: Dimension): Map<Int, BigDecimal> {
-        var zoneMap = HashMap<Int, BigDecimal>()
+        var zoneMap = LinkedHashMap<Int, BigDecimal>()
         var targetRadius = targetSize.value.toBigDecimal().div(BigDecimal.valueOf(2))
         // TODO: convert to unit in a bit
         for ((zoneIndex, score) in scoringStyle.getPointsList().iterator().withIndex()) {

--- a/shared/src/main/java/de/dreier/mytargets/shared/targets/models/WAFull.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/targets/models/WAFull.kt
@@ -50,7 +50,7 @@ class WAFull : TargetModelBase(
                 ScoringStyle(R.string.compound_style, false, 10, 9, 9, 8, 7, 6, 5, 4, 3, 2, 1),
                 ScoringStyle(false, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1),
                 ScoringStyle(true, 5, 5, 5, 4, 4, 3, 3, 2, 2, 1, 1),
-                ScoringStyle(false, 9, 9, 9, 7, 7, 5, 5, 3, 3, 1, 1),
+                ScoringStyle(R.string.imperial_outdoor_5_zone, false, 9, 9, 9, 7, 7, 5, 5, 3, 3, 1, 1),
                 ColorScoringStyle(R.string.fcfs_color_reversed, 31, 1, 1, 2, 4, 4, 6, 6, 8, 8, 10, 10)
         ),
         diameters = listOf(

--- a/shared/src/main/java/de/dreier/mytargets/shared/targets/scoringstyle/ScoringStyle.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/targets/scoringstyle/ScoringStyle.kt
@@ -97,6 +97,10 @@ open class ScoringStyle private constructor(
         return shots.map { getReachedScore(it) }.sum()
     }
 
+    open fun getPointsList(): IntArray {
+        return points[0]
+    }
+
     companion object {
         const val MISS_SYMBOL = "M"
         private const val X_SYMBOL = "X"

--- a/shared/src/main/res/values-de/target_faces.xml
+++ b/shared/src/main/res/values-de/target_faces.xml
@@ -60,4 +60,7 @@
     <string name="recurve_style_x_8">Recurve-Stil (X-8)</string>
     <string name="recurve_style_10_8">Recurve-Stil (10-8)</string>
     <string name="compound_style">Compound-Stil</string>
+    <string name="imperial_outdoor_5_zone">Imperiale Außen 5 Zone</string>
+
+
 </resources>

--- a/shared/src/main/res/values-es/target_faces.xml
+++ b/shared/src/main/res/values-es/target_faces.xml
@@ -60,4 +60,6 @@
     <string name="recurve_style_x_8">Estilo recurvo (X-8)</string>
     <string name="recurve_style_10_8">Estilo recurvo (10-8)</string>
     <string name="compound_style">Estilo compuesto</string>
+    <string name="imperial_outdoor_5_zone">Imperial Zona 5</string>
+
 </resources>

--- a/shared/src/main/res/values-fr/target_faces.xml
+++ b/shared/src/main/res/values-fr/target_faces.xml
@@ -60,4 +60,6 @@
     <string name="recurve_style_x_8">Style classique (X-8)</string>
     <string name="recurve_style_10_8">Style classique (10-8)</string>
     <string name="compound_style">Style poulies</string>
+    <string name="imperial_outdoor_5_zone">Imperial extérieure Zone 5</string>
+
 </resources>

--- a/shared/src/main/res/values/target_faces.xml
+++ b/shared/src/main/res/values/target_faces.xml
@@ -61,6 +61,6 @@
     <string name="recurve_style_x_8">Recurve style (X–8)</string>
     <string name="recurve_style_10_8">Recurve style (10–8)</string>
     <string name="compound_style">Compound style</string>
-    <string name="imperial_outdoor_5_zone">Imperial Outdoor 5 Zone</string>
+    <string name="imperial_outdoor_5_zone">Imperial 5 Zone</string>
 
 </resources>

--- a/shared/src/main/res/values/target_faces.xml
+++ b/shared/src/main/res/values/target_faces.xml
@@ -61,4 +61,6 @@
     <string name="recurve_style_x_8">Recurve style (X–8)</string>
     <string name="recurve_style_10_8">Recurve style (10–8)</string>
     <string name="compound_style">Compound style</string>
+    <string name="imperial_outdoor_5_zone">Imperial Outdoor 5 Zone</string>
+
 </resources>


### PR DESCRIPTION
Hi folks,
This PR implements the handicap calculations that were previously discussed. I've not linked it to an issue as one does not exist and the original repo is closed so cannot create new issues there.
This calculates the handicap as per David Lane's formulae. It will display this in the stats page of the round. It will also give you the handicap of each distance shot during that round so you can see which ones you performed better on.

![Selection_204](https://user-images.githubusercontent.com/1842379/112056584-17ed3c00-8b50-11eb-95ce-ca1b778da4b4.png)

I've had to rework the stats view a little - you can now see I've put the Hits and Average (Ø) on separate line and added the handicap on the end of that line denoted by a sigma (∑). Not sure that sigma is the correct icon for this but can't think what else would be a good one and sigma features a lot in the integration formulae. A staircase would be ideal but can't find one of them as a UTF8 character.

Happy to change anything that doesn't make sense though.

All of the calculation functions are covered with tests I think (I hope!!). A lot of the test cases have multiple assertions. This is down to the fact that rounding issues can easily skew a handicap by a point on the boundaries. Rather than have a mass of boiler plate that sets up the same test data a bunch of times, I used multiple assertions instead. Entirely possible there are some other boundary issues I haven't discovered yet, but I did to a fair amount of table comparison that wasn't worth putting into extra tests as that may just make refactoring more onerous later down the line.