### PR TITLE
JM: Free training now correctly calculates Handicap

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,8 +39,8 @@ android {
         applicationId 'de.dreier.mytargets'
         minSdkVersion 16
         targetSdkVersion 28
-        versionCode 305
-        versionName "3.0.5"
+        versionCode 306
+        versionName "3.0.6"
         vectorDrawables.useSupportLibrary true
         javaCompileOptions {
             annotationProcessorOptions {

--- a/app/src/main/res/raw/help.html
+++ b/app/src/main/res/raw/help.html
@@ -105,12 +105,13 @@
                     </ul>
                 </details>
                 <details>
-                   <summary>Handicaps</summary>
+                   <summary>Handicaps (∑)</summary>
                     <p>Where used in table summaries with limited space, may be denoted with "∑" symbol.</p>
-                    <p>Note that the calculation is based on a complete round so will *not* be accurate on partly completed rounds currently.</p>
+                    <p>They are calculated as per the formulae developed by David Lane.</p>
+                    <p>Note that the handicap will recalculate as you enter shots, so can be used to track how well you are doing as you go along in a single round or free training. However, for a round that comprises of sub-rounds (eg. York) the overall handicap will only be accurate after all rounds have been completed.</p>
                     <p>Also note that the calculation will vary with arrow diameter. If you have not set this, then it will default to the accepted 'average' spine - 1816 (diameter 7.14mm)</p>
                     <p>Handicaps are calculated and shown for each round and also for different distances during the round</p>
-                    <p>They are calculated as per the formulae developed by David Lane. His work is documented here:</p>
+                    <p> David Lane's work is documented in the links here:</p>
                     <ul>
                         <li>"The Construction of the Graduated Handicap Tables for Target Archery", David Lane, Sep 2013.</li>
                         <li>"Handicap Tables", David Lane, published in Toxophilus Vol II Number 1 1979</li>

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -366,7 +366,7 @@ class HandicapCalculatorTest {
         var distance = Dimension(70f, Dimension.Unit.METER)
         var diameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var target = Target(WAFull.ID, 1,  diameter)
-        var score = Score(222, 720)
+        var score = Score(222, 720, 36)
         var round = Round(0, 0, 0, 6, 6, distance, "test", target, score )
 
         var unit = HandicapCalculator(round)
@@ -393,7 +393,7 @@ class HandicapCalculatorTest {
         var distance = Dimension(76.5529f, Dimension.Unit.YARDS)
         var diameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var target = Target(WAFull.ID, 0,  diameter)
-        var score = Score(341, 999)
+        var score = Score(341, 999, 72)
         var round = Round(0, 0, 0, 6, 12, distance, "test", target, score )
 
         var unit = HandicapCalculator(round)
@@ -410,7 +410,7 @@ class HandicapCalculatorTest {
         var distance = Dimension(70f, Dimension.Unit.METER)
         var diameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var target = Target(WAFull.ID, 0, diameter)
-        var score = Score(647, 720)
+        var score = Score(647, 720, 72)
         var round = Round(0, 0, 0, 6, 12, distance, "test", target, score)
 
         var unit = HandicapCalculator(round)

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/MultiRoundHandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/MultiRoundHandicapCalculatorTest.kt
@@ -110,7 +110,7 @@ class MultiRoundHandicapCalculatorTest {
         var longDistance = Dimension(70f, Dimension.Unit.METER)
         var longDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var longTarget = Target(WAFull.ID, 0, longDiameter)
-        var longScore = Score(685, 720)
+        var longScore = Score(685, 720, 72)
         var longRound = Round(0, 0, 0, 6, 12, longDistance, "70m", longTarget, longScore)
 
         var arrowDiameter = Dimension(0.714f, Dimension.Unit.CENTIMETER)
@@ -131,13 +131,13 @@ class MultiRoundHandicapCalculatorTest {
         var longDistance = Dimension(25f, Dimension.Unit.METER)
         var longDiameter = Dimension(60f, Dimension.Unit.CENTIMETER)
         var longTarget = Target(WAFull.ID, 0, longDiameter)
-        var longScore = Score(590, 600)
+        var longScore = Score(590, 600, 60)
         var longRound = Round(0, 0, 0, 3, 20, longDistance, "100y", longTarget, longScore)
 
         var shortDistance = Dimension(18f, Dimension.Unit.METER)
         var shortDiameter = Dimension(40f, Dimension.Unit.CENTIMETER)
         var shortTarget = Target(WAFull.ID, 0, shortDiameter)
-        var shortScore = Score(591, 600)
+        var shortScore = Score(591, 600, 60)
         var shortRound = Round(0, 0, 0, 3, 20, shortDistance, "60y", shortTarget, shortScore)
 
         var arrowDiameter = Dimension(0.714f, Dimension.Unit.CENTIMETER)
@@ -169,19 +169,19 @@ class MultiRoundHandicapCalculatorTest {
         var longDistance = Dimension(100f, Dimension.Unit.YARDS)
         var longDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var longTarget = Target(WAFull.ID, 5, longDiameter)
-        var longScore = Score(504, 648)
+        var longScore = Score(504, 648, 72)
         var longRound = Round(0, 0, 0, 6, 12, longDistance, "100y", longTarget, longScore)
 
         var midDistance = Dimension(80f, Dimension.Unit.YARDS)
         var midDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var midTarget = Target(WAFull.ID, 5, midDiameter)
-        var midScore = Score(336, 432)
+        var midScore = Score(336, 432, 48)
         var midRound = Round(0, 0, 0, 6, 8, midDistance, "80y", midTarget, midScore)
 
         var shortDistance = Dimension(60f, Dimension.Unit.YARDS)
         var shortDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
         var shortTarget = Target(WAFull.ID, 5, shortDiameter)
-        var shortScore = Score(168, 216)
+        var shortScore = Score(168, 216, 24)
         var shortRound = Round(0, 0, 0, 6, 4, shortDistance, "60y", shortTarget, shortScore)
 
         var arrowDiameter = Dimension(0.714f, Dimension.Unit.CENTIMETER)

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -28,7 +28,7 @@ import kotlin.math.pow
 
 class HandicapCalculator {
     constructor(round: Round) {
-        this.arrowCount = round.shotsPerEnd * round.maxEndCount!!
+        this.arrowCount = round.score.shotCount
         this.targetModel = round.target.model
         this.scoringStyle = round.target.getScoringStyle()
         this.targetSize = round.target.diameter


### PR DESCRIPTION
Hi folks,

That should fix the issue of the NPE in the HandicapCalculator PR - https://github.com/crobertsbmw/MyTargets/pull/3

As it happens, the swiftest fix was to implement one of the features you'd queried about, namely to make the calculation based on the current number of arrows shot rather than the total expected arrows of the entire round.

This does mean that somebody could potentially not record some misses as being shot and their handicap would then be artificially better. However, since the scoreboard shows the number of arrows registered, if anyone was using this for calculations in, for example, a club comp, then they could see that the number of arrows shot was incorrect and go back and record them, so do not think it's an issue.

I have also bumped the version from 3.0.5 to 3.0.6 as I think it may be confusing the play store. If you don't want this, then revert that file.

Cheers!
