### PR TITLE
Fix incorrect calculation for imperial rounds

### DIFF
--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorRoundingTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorRoundingTest.kt
@@ -1,0 +1,121 @@
+/*
+ * MyTargets Project Copyright (C) 2018 Florian Dreier
+ *
+ * This file is (c) 2021 Jez McKinley - Canford Magna Bowmen
+ *
+ * Calculations used in this file are courtesy of Jack Atkinson - see:
+ * https://www.jackatkinson.net/post/archery_handicap/
+ * derived from David Lane's Handicap Calcs for Toxophilus 1979
+ *
+ * MyTargets is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * MyTargets is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+package de.dreier.mytargets.shared.targets.models
+
+import android.content.Context
+import androidx.test.filters.SmallTest
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
+import de.dreier.mytargets.shared.SharedApplicationInstance
+import de.dreier.mytargets.shared.models.Dimension
+import de.dreier.mytargets.shared.models.HandicapCalculator
+import de.dreier.mytargets.shared.models.Score
+import de.dreier.mytargets.shared.models.Target
+import de.dreier.mytargets.shared.models.db.Round
+import org.hamcrest.CoreMatchers
+import org.hamcrest.MatcherAssert
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@SmallTest
+@RunWith(AndroidJUnit4::class)
+class HandicapCalculatorRoundingTest {
+    private lateinit var context: Context
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        SharedApplicationInstance.context = InstrumentationRegistry.getInstrumentation().targetContext
+    }
+
+    fun assertBigDecimalEquals(expected: BigDecimal, actual: BigDecimal, scale: Int=2, roundingMode: RoundingMode=RoundingMode.HALF_UP) {
+        assertEquals(expected.setScale(scale, roundingMode), actual.setScale(scale, roundingMode))
+    }
+
+    fun assertBigDecimalEquals(expected: String, actual: BigDecimal, scale: Int=2, roundingMode: RoundingMode=RoundingMode.HALF_UP) {
+        assertEquals(BigDecimal(expected).setScale(scale, roundingMode), actual.setScale(scale, roundingMode))
+    }
+
+    fun assertBigDecimalEquals(expected: Int, actual: BigDecimal, scale: Int=2, roundingMode: RoundingMode=RoundingMode.HALF_UP) {
+        assertEquals(BigDecimal(expected.toString()).setScale(scale, roundingMode), actual.setScale(scale, roundingMode))
+    }
+
+    private fun checkArraysEqual(expected: ArrayList<Int>, actual: List<BigDecimal>) {
+        for ((index, item) in expected.withIndex()) {
+            val actualItem = actual.get(index)
+            val message = "Item at index: $index should be -- $item -- but was -- $actualItem --"
+            assertEquals(message, BigDecimal(item.toString()), BigDecimal(actualItem.toString()))
+        }
+    }
+
+    @Test
+    fun check_distance_conversion_yards_to_metres_rounds_correctly() {
+        var longDistance = Dimension(60f, Dimension.Unit.YARDS)
+        var unit = HandicapCalculator()
+        unit.setTargetDistance(longDistance)
+        assertEquals(BigDecimal("54.86400"), unit.metricDistance)
+    }
+
+    @Test
+    fun dimensionToString() {
+        var unit = Dimension(22.5487f, Dimension.Unit.CENTIMETER)
+        MatcherAssert.assertThat(unit.formatString(), CoreMatchers.equalTo("22.5487 cm"))
+
+        unit = Dimension(22.54f, Dimension.Unit.INCH)
+        MatcherAssert.assertThat(unit.formatString(), CoreMatchers.equalTo("22.54 in"))
+    }
+
+    @Test
+    fun rounding_errors_test_imperial_round() {
+        // YARDS, CENTIMETER,
+        // first params here are targetface, scoringstyle and shotsperend, the tuples are distance, diameter and ends
+        // WAFull.ID, 5, 6, 100, 122, 12, 80, 122, 8, 60, 122, 4
+        var longDistance = Dimension(60f, Dimension.Unit.YARDS)
+        var longDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
+        var longTarget = Target(WAFull.ID, 5, longDiameter)
+        var longScore = Score(219, 432, 72)
+        var longRound = Round(0, 0, 0, 6, 12, longDistance, "60y", longTarget, longScore)
+
+        val scoreList = arrayListOf<Int>(
+                648, 648, 648, 648, 648, 648, 647, 647, 647, 646, 646, 645, 644, 642, 641, 639, 638, 635, 633, 630,
+                628, 624, 621, 618, 614, 610, 606, 601, 597, 592, 587, 582, 576, 570, 564, 558, 551, 544, 537, 530,
+                521, 513, 504, 495, 485, 475, 464, 453, 441, 428, 415, 401, 387, 372, 357, 341, 325, 308, 292, 275,
+                258, 241, 224, 208, 192, 177, 162, 148, 134, 121, 109, 98, 88, 78, 69, 61, 54, 47, 42, 36, 32, 27,
+                24, 20, 18, 15, 13, 11, 9, 8, 7, 6, 5, 4, 3, 3, 2, 2, 2, 1, 1
+        )
+
+        var arrowDiameter = Dimension(0.28125f, Dimension.Unit.INCH)
+        var arrowRadius = BigDecimal((arrowDiameter.convertTo(Dimension.Unit.CENTIMETER).value / 2).toString()).setScale(3, RoundingMode.HALF_UP)
+        assertEquals(arrowRadius, BigDecimal("0.357"))
+        var unit = HandicapCalculator(longRound)
+
+        assertEquals(0.000155355997, unit.handicapCoefficient(65), 0.0000000001)
+        assertEquals(BigDecimal("1.467630639"), unit.dispersionFactor(65))
+        assertEquals(BigDecimal("0.4504199138"), unit.angularDeviation(65))
+
+        var calculated = unit.handicapScoresList()
+        checkArraysEqual(scoreList, calculated)
+    }
+
+}

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -247,6 +247,7 @@ class HandicapCalculatorTest {
         unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(70.0f, Dimension.Unit.METER))
         assertBigDecimalEquals(BigDecimal("6.8828612028"), unit.averageArrowScoreForHandicap(36))
+        assertBigDecimalEquals(BigDecimal("1.21412401363123"), unit.averageArrowScoreForHandicap(65))
 
         // 122cm, 80y (73.152m)
         unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))

--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/MultiRoundHandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/MultiRoundHandicapCalculatorTest.kt
@@ -203,15 +203,39 @@ class MultiRoundHandicapCalculatorTest {
         assertThat(unit.getHandicapForScore(996), equalTo(32))
     }
 
+
     @Test
-    fun dimensionToString() {
-        var unit = Dimension(22.5487f, Dimension.Unit.CENTIMETER)
-        assertThat(unit.formatString(), equalTo("22.5487 cm"))
+    fun handicap_for_national_round_fatter_arrow() {
+        //        WA, R.string.wa_combined,
+        //        Dimension.Unit.YARD, CENTIMETER,
+        // first params here are targetface, scoringstyle and shotsperend, the tuples are distance, diameter and ends
+        //        WAFull.ID, 0, 3, 25, 60, 20, 18, 40, 20
+        var longDistance = Dimension(60f, Dimension.Unit.YARDS)
+        var longDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
+        var longTarget = Target(WAFull.ID, 5, longDiameter)
+        var longScore = Score(219, 432, 48)
+        var longRound = Round(0, 0, 0, 6, 8, longDistance, "60y", longTarget, longScore)
 
-        unit = Dimension(22.54f, Dimension.Unit.INCH)
-        assertThat(unit.formatString(), equalTo("22.54 in"))
+        var shortDistance = Dimension(50f, Dimension.Unit.YARDS)
+        var shortDiameter = Dimension(122f, Dimension.Unit.CENTIMETER)
+        var shortTarget = Target(WAFull.ID, 5, shortDiameter)
+        var shortScore = Score(140, 216, 24)
+        var shortRound = Round(0, 0, 0, 6, 4, shortDistance, "50y", shortTarget, shortScore)
+
+        var arrowDiameter = Dimension(0.34375f, Dimension.Unit.INCH)
+        var rounds = ArrayList<Round>()
+        rounds.add(longRound)
+        rounds.add(shortRound)
+        var unit = MultiRoundHandicapCalculator(rounds, arrowDiameter)
+
+        assertThat(unit.getHandicap(), equalTo(56))
+
+        assertThat(unit.getHandicapForScore(648), equalTo(0))
+        assertThat(unit.getHandicapForScore(647), equalTo(7))
+        assertThat(unit.getHandicapForScore(382), equalTo(54))
+        assertThat(unit.getHandicapForScore(62), equalTo(77))
+
     }
-
 
 }
 

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/Dimension.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/Dimension.kt
@@ -50,7 +50,8 @@ data class Dimension(val value: Float, val unit: Unit?) : IIdProvider, Comparabl
         if (this.unit == null) {
             return Dimension((8f - this.value) * 4f, Unit.CENTIMETER).convertTo(unit)
         }
-        val newValue = value * unit.factor / this.unit.factor
+        val multiplier = unit.factor / this.unit.factor
+        val newValue = value * multiplier
         return Dimension(newValue, unit)
     }
 

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -124,23 +124,6 @@ class HandicapCalculator {
         val bestArrowScore = BigDecimal(zoneMap.keys.max().toString())
 
         var zoneScoreStep = (zoneMap.keys.elementAt(0) - zoneMap.keys.elementAt(1))
-        if (zoneScoreStep == 2) {
-            return imperialCalc(zoneMap, groupRadiusSquared, bestArrowScore, zoneScoreStep)
-        } else {
-            return metricCalc(zoneMap, groupRadiusSquared, bestArrowScore)
-        }
-    }
-
-    private fun metricCalc(zoneMap: Map<Int, BigDecimal>, groupRadiusSquared: BigDecimal, bestArrowScore: BigDecimal): BigDecimal {
-        var exponentTotals = BigDecimal(0)
-        for ((index, radius) in zoneMap.iterator()) {
-            var zoneRadiusSquared = (radius + arrowRadius).pow(2)
-            exponentTotals += BigDecimal.valueOf(exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
-        }
-        return (bestArrowScore - exponentTotals)
-    }
-
-    private fun imperialCalc(zoneMap: Map<Int, BigDecimal>, groupRadiusSquared: BigDecimal, bestArrowScore: BigDecimal, zoneScoreStep: Int): BigDecimal {
         var exponentTotals = BigDecimal(0)
         var lastEntry = zoneMap.entries.last()
         for ((index, radius) in zoneMap.iterator()) {

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -70,7 +70,15 @@ class HandicapCalculator {
 
     fun setTargetDistance(distanceDimension: Dimension) {
         targetDistance = distanceDimension
-        this.metricDistance = BigDecimal.valueOf(distanceDimension.convertTo(Dimension.Unit.METER).value.toDouble())
+        if(distanceDimension.unit == Dimension.Unit.YARDS) {
+            this.metricDistance = BigDecimal("0.9144").times(BigDecimal(distanceDimension.value.toString()))
+        } else {
+            this.metricDistance = BigDecimal(distanceDimension.value.toString())
+        }
+    }
+    fun roundToSigFigures(numberToRound: BigDecimal, precision: Int=10): BigDecimal {
+        val newScale = numberToRound.scale() + precision - numberToRound.precision()
+        return numberToRound.setScale(newScale, RoundingMode.HALF_UP)
     }
 
     fun setScoringStyle(scoringStyle: ScoringStyle) {
@@ -96,12 +104,12 @@ class HandicapCalculator {
     }
 
     fun angularDeviation(handicap: Int): BigDecimal {
-        return  BigDecimal.valueOf((1.036.pow(handicap+12.9))*5*(10.0.pow(-4))*180/Math.PI)
+        return roundToSigFigures(BigDecimal.valueOf((1.036.pow(handicap+12.9))*5*(10.0.pow(-4))*180/Math.PI))
     }
 
     fun dispersionFactor(handicap: Int): BigDecimal {
         //F=1 + 1.429*10^-6 * 1.07^(handicap+4.3) * distance_in_metres^2
-        return BigDecimal.valueOf(1 + 1.429 * (10.0.pow(-6)) * 1.07.pow(handicap+4.3) * metricDistance.toDouble().pow(2))
+        return roundToSigFigures(BigDecimal.valueOf(1 + 1.429 * (10.0.pow(-6)) * 1.07.pow(handicap+4.3) * metricDistance.toDouble().pow(2)))
     }
 
     fun groupRadius(handicap: Int): BigDecimal {
@@ -138,7 +146,7 @@ class HandicapCalculator {
         for ((index, radius) in zoneMap.iterator()) {
             var zoneRadiusSquared = (radius + arrowRadius).pow(2)
             if (radius == lastEntry.value) {
-                exponentTotals -= BigDecimal.valueOf(exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
+                exponentTotals += BigDecimal.valueOf(exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
             } else {
                 exponentTotals += BigDecimal.valueOf(zoneScoreStep * exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
             }
@@ -150,7 +158,6 @@ class HandicapCalculator {
         val decimalPlaces: Int = if (rounded) 0 else 2
         var handicapList = ArrayList<BigDecimal>()
         for (handicap: Int in  handicapLowerBound()..handicapUpperBound()) {
-//            handicapList.add((BigDecimal(arrowCount) * averageArrowScoreForHandicap(handicap).setScale(2, RoundingMode.HALF_UP)).setScale(0, RoundingMode.UP).toInt())
             var average = averageArrowScoreForHandicap(handicap)
             var roundScore = (BigDecimal(arrowCount) * average)
             handicapList.add(roundScore.setScale(decimalPlaces, RoundingMode.HALF_UP))
@@ -172,6 +179,13 @@ class HandicapCalculator {
     fun getHandicap(): Int {
         return getHandicapForScore(this.reachedScore)
     }
+
+//    =8 - 2*(
+//    EXP(-(((0*$D$8/10)+$D$7)^2)/$F81^2) +  0.9833536318
+//    EXP(-(((1*$D$8/10)+$D$7)^2)/$F81^2) +  0.9368336662
+//    EXP(-(((2*$D$8/10)+$D$7)^2)/$F81^2) +  0.8646739809
+//    EXP(-(((3*$D$8/10)+$D$7)^2)/$F81^2)) -  0.7731778975
+//    EXP(-(((4*$D$8/10)+$D$7)^2)/$F81^2)  0.6697976335
 
 //arrowDiameterCm=arrow_diameter_cm  (0.357cm) 18/64
 //targetSizeCm=target_size_cm (122)

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/MultiRoundHandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/MultiRoundHandicapCalculator.kt
@@ -37,7 +37,7 @@ class MultiRoundHandicapCalculator{
             for (roundHandicapScoreList: List<BigDecimal> in roundHandicapScoreLists) {
                 totalForHandicap += roundHandicapScoreList.get(handicap)
             }
-            handicapList.add(totalForHandicap.setScale(0, RoundingMode.DOWN))
+            handicapList.add(totalForHandicap.setScale(0, RoundingMode.HALF_UP))
         }
         return  handicapList
     }


### PR DESCRIPTION
Hi folks,

This PR fixes an issue where as the score drops, the handicap boundaries drift from the official calculations on an imperial round.

An imperial round is one where the target rings are scored as 9,7,5,3,1 instead of 10,9,8,7,6,5,4,3,2,1 but that the face is a 10 ring face still. It therefore has to treat the 10 and 9 rings as 9, the 8 and 7 as 7 etc.

Added a few tests to cover this with popular imperial rounds (National and York)

Also extended some tests to cover lower scores and also fatter arrows. Fatter arrows were covered in earlier tests but hadn't specifically checked it across multiple rounds. The functionality of the fatter arrow calc itself did not need to change.

Examples to show the difference:
National Round (60/50 yards) 122cm face, Arrow diameter: 22/64in / 0.34375cm
Score:    281    Current calc: 60    Corrected calc: 61
Score:    359    Current calc: 57    Corrected calc: 56