### PR TITLE
fix imperial average arrow score

### DIFF
--- a/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
+++ b/shared/src/androidTest/java/de/dreier/mytargets/shared/targets/models/HandicapCalculatorTest.kt
@@ -253,11 +253,15 @@ class HandicapCalculatorTest {
         unit.setTargetDistance(Dimension(80.0f, Dimension.Unit.YARDS))
         assertBigDecimalEquals(BigDecimal("6.7122107117"), unit.averageArrowScoreForHandicap(36))
 
+        // 122cm, 80y (73.152m)
+        unit.setTargetSize(Dimension(122f, Dimension.Unit.CENTIMETER))
+        unit.setTargetDistance(Dimension(80.0f, Dimension.Unit.YARDS))
+        assertBigDecimalEquals(BigDecimal("0.1981725984"), unit.averageArrowScoreForHandicap(77))
+
         // 60cm, 18m
         unit.setTargetSize(Dimension(60f, Dimension.Unit.CENTIMETER))
         unit.setTargetDistance(Dimension(18.0f, Dimension.Unit.METER))
         assertBigDecimalEquals(BigDecimal("8.9152743398"), unit.averageArrowScoreForHandicap(26))
-
     }
 
     @Test

--- a/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/models/HandicapCalculator.kt
@@ -138,7 +138,7 @@ class HandicapCalculator {
         for ((index, radius) in zoneMap.iterator()) {
             var zoneRadiusSquared = (radius + arrowRadius).pow(2)
             if (radius == lastEntry.value) {
-                exponentTotals -= BigDecimal.valueOf(exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
+                exponentTotals += BigDecimal.valueOf(exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
             } else {
                 exponentTotals += BigDecimal.valueOf(zoneScoreStep * exp(-(zoneRadiusSquared / groupRadiusSquared).toDouble()))
             }


### PR DESCRIPTION
The sign error here wasn't picked up by tests because they only use low handicap values, and these terms were too small to affect the average after rounding.

The error is fairly noticeable if you shoot a bowstyle like longbow where handicaps are usually higher. The app often returns 101, but the handicaps are often subtly wrong.